### PR TITLE
Add keyed enrich type tests and minimal type surface

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -4,6 +4,7 @@ import {
     type ImmutableProps,
     type Pipeline,
     type PipelineInput,
+    type PipelineSources,
     type PipelineRuntimeDiagnostic,
     type PipelineRuntimeDisposeOptions,
     type PipelineRuntimeOptions,
@@ -53,7 +54,7 @@ type KeyedRecursivePlain<T> =
  * type Row = PipelineOutput<typeof builder>;
  */
 export type PipelineOutput<TBuilder> =
-    TBuilder extends PipelineBuilder<infer T, infer _S, infer _Path, infer _Root> ? T : never;
+    TBuilder extends PipelineBuilder<infer T, infer _S, infer _Path, infer _Root, infer _Sources> ? T : never;
 
 /**
  * Same structure as {@link PipelineOutput} but with every {@link KeyedArray} replaced by a plain array.
@@ -86,9 +87,11 @@ interface RuntimeApplyContext {
     emitDiagnostic: (diagnostic: PipelineRuntimeDiagnostic) => void;
 }
 
-class PipelineRuntimeSessionImpl<TState extends object, TStart> implements Pipeline<TStart> {
+class PipelineRuntimeSessionImpl<TState extends object, TStart, TSources extends Record<string, unknown> = {}>
+    implements Pipeline<TStart, TSources> {
     private readonly setState: (transform: Transform<KeyedArray<TState>>) => void;
-    private readonly inputPipeline: PipelineInput<TStart>;
+    private readonly inputPipeline: PipelineInput<TStart, TSources>;
+    readonly sources: PipelineSources<TSources>;
     private readonly runtimeOptions: Required<Pick<PipelineRuntimeOptions, 'batchSize' | 'flushDelayMs'>> &
         Pick<PipelineRuntimeOptions, 'onDiagnostic'>;
     private pendingOperations: PendingOperation[] = [];
@@ -97,11 +100,12 @@ class PipelineRuntimeSessionImpl<TState extends object, TStart> implements Pipel
     private epoch = 1;
 
     constructor(
-        pipeline: PipelineInput<TStart>,
+        pipeline: PipelineInput<TStart, TSources>,
         setState: (transform: Transform<KeyedArray<TState>>) => void,
         runtimeOptions: PipelineRuntimeOptions
     ) {
         this.inputPipeline = pipeline;
+        this.sources = pipeline.sources;
         this.setState = setState;
         this.runtimeOptions = {
             batchSize: runtimeOptions.batchSize ?? 50,
@@ -361,6 +365,8 @@ type CurrentScopeName<Path extends string[], RootScopeName extends string> =
         ? LastSegment
         : RootScopeName;
 
+type PreserveStringLiterals<T extends readonly string[]> = string extends T[number] ? string[] : T;
+
 function compareMixedPrimitiveValues(left: number | string, right: number | string): number {
     if (typeof left === 'number' && typeof right === 'number') {
         return left - right;
@@ -390,9 +396,15 @@ function compareMixedPrimitiveValues(left: number | string, right: number | stri
  * Removes an array at the specified path from the type.
  */
 
-export class PipelineBuilder<T extends object, TStart, Path extends string[] = [], RootScopeName extends string = 'items'> {
+export class PipelineBuilder<
+    T extends object,
+    TStart,
+    Path extends string[] = [],
+    RootScopeName extends string = 'items',
+    TSources extends Record<string, unknown> = {}
+> {
     constructor(
-        private input: PipelineInput<TStart>,
+        private input: PipelineInput<TStart, TSources>,
         private lastStep: Step,
         private scopeSegments: Path = [] as unknown as Path
     ) {}
@@ -418,7 +430,8 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<K, U>>>,
         TStart,
         Path,
-        RootScopeName
+        RootScopeName,
+        TSources
     > {
         const newStep = new DefinePropertyStep(
             this.lastStep,
@@ -436,7 +449,8 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             : Expand<TransformAtPath<T, Path, Expand<Omit<NavigateToPath<T, Path>, K>>>>,
         TStart,
         Path,
-        RootScopeName
+        RootScopeName,
+        TSources
     > {
         const newStep = new DropPropertyStep<NavigateToPath<T, Path>, K>(
             this.lastStep,
@@ -455,7 +469,8 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             : Expand<TransformAtPath<T, Path, { [P in K]: NavigateToPath<T, Path>[P] } & { [P in CurrentScopeName<Path, RootScopeName>]: KeyedArray<{ [Q in Exclude<keyof NavigateToPath<T, Path>, K>]: NavigateToPath<T, Path>[Q] }> }>>,
         TStart,
         Path,
-        Path extends [] ? ArrayName : RootScopeName
+        Path extends [] ? ArrayName : RootScopeName,
+        TSources
     > {
         const descriptor = this.lastStep.getTypeDescriptor();
         const inferredChildArrayName = this.scopeSegments.length > 0
@@ -539,7 +554,8 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<PropName, TAggregate>>>,
         TStart,
         Path,
-        RootScopeName
+        RootScopeName,
+        TSources
     > {
         const fullSegmentPath = [...this.scopeSegments, arrayName];
         const newStep = new CommutativeAggregateStep(
@@ -580,7 +596,8 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TPropName, number>>>,
         TStart,
         Path,
-        RootScopeName
+        RootScopeName,
+        TSources
     > {
         return this.commutativeAggregate(
             arrayName,
@@ -622,7 +639,8 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TPropName, number>>>,
         TStart,
         Path,
-        RootScopeName
+        RootScopeName,
+        TSources
     > {
         return this.commutativeAggregate(
             arrayName,
@@ -657,7 +675,8 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TPropName, number | undefined>>>,
         TStart,
         Path,
-        RootScopeName
+        RootScopeName,
+        TSources
     > {
         const fullSegmentPath = [...this.scopeSegments, arrayName];
         const newStep = new MinMaxAggregateStep(
@@ -695,7 +714,8 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TPropName, number | undefined>>>,
         TStart,
         Path,
-        RootScopeName
+        RootScopeName,
+        TSources
     > {
         const fullSegmentPath = [...this.scopeSegments, arrayName];
         const newStep = new MinMaxAggregateStep(
@@ -733,7 +753,8 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TPropName, number | undefined>>>,
         TStart,
         Path,
-        RootScopeName
+        RootScopeName,
+        TSources
     > {
         const fullSegmentPath = [...this.scopeSegments, arrayName];
         const newStep = new AverageAggregateStep(
@@ -771,7 +792,8 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TPropName, ArrayItemAtCurrentPath<T, Path, ArrayName> | undefined>>>,
         TStart,
         Path,
-        RootScopeName
+        RootScopeName,
+        TSources
     > {
         const fullSegmentPath = [...this.scopeSegments, arrayName];
         const newStep = new PickByMinMaxStep(
@@ -810,7 +832,8 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TPropName, ArrayItemAtCurrentPath<T, Path, ArrayName> | undefined>>>,
         TStart,
         Path,
-        RootScopeName
+        RootScopeName,
+        TSources
     > {
         const fullSegmentPath = [...this.scopeSegments, arrayName];
         const newStep = new PickByMinMaxStep(
@@ -832,8 +855,8 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
      */
     in<NewPath extends string[]>(
         ...pathSegments: NewPath
-    ): PipelineBuilder<T, TStart, [...Path, ...NewPath], RootScopeName> {
-        return new PipelineBuilder<T, TStart, [...Path, ...NewPath], RootScopeName>(
+    ): PipelineBuilder<T, TStart, [...Path, ...NewPath], RootScopeName, TSources> {
+        return new PipelineBuilder<T, TStart, [...Path, ...NewPath], RootScopeName, TSources>(
             this.input,
             this.lastStep,
             [...this.scopeSegments, ...pathSegments] as [...Path, ...NewPath]
@@ -857,7 +880,7 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
     filter(
         predicate: (item: NavigateToPath<T, Path>) => boolean,
         mutableProperties: string[] = []
-    ): PipelineBuilder<T, TStart, Path, RootScopeName> {
+    ): PipelineBuilder<T, TStart, Path, RootScopeName, TSources> {
         const newStep = new FilterStep<NavigateToPath<T, Path>>(
             this.lastStep,
             predicate as (item: unknown) => boolean,
@@ -865,6 +888,37 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             mutableProperties
         );
         return new PipelineBuilder(this.input, newStep, this.scopeSegments);
+    }
+
+    enrich<
+        TSourceName extends string,
+        TSecondary extends object,
+        TSecondaryStart extends object,
+        TSecondaryRootScopeName extends string,
+        TSecondarySources extends Record<string, unknown>,
+        TPrimaryKey extends keyof NavigateToPath<T, Path> & string,
+        TAs extends string
+    >(
+        sourceName: TSourceName,
+        secondaryPipeline: PipelineBuilder<TSecondary, TSecondaryStart, [], TSecondaryRootScopeName, TSecondarySources>,
+        primaryKey: PreserveStringLiterals<readonly TPrimaryKey[]>,
+        as: TAs,
+        whenMissing?: TSecondary
+    ): PipelineBuilder<
+        Path extends []
+            ? Expand<T & Record<TAs, TSecondary>>
+            : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TAs, TSecondary>>>,
+        TStart,
+        Path,
+        RootScopeName,
+        TSources & Record<TSourceName, { primary: TSecondaryStart; sources: TSecondarySources }>
+    > {
+        void sourceName;
+        void secondaryPipeline;
+        void primaryKey;
+        void as;
+        void whenMissing;
+        throw new Error('PipelineBuilder.enrich is not implemented yet.');
     }
 
     getTypeDescriptor(): TypeDescriptor {
@@ -878,10 +932,10 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
     build(
         setState: (transform: Transform<KeyedArray<T>>) => void,
         runtimeOptions: PipelineRuntimeOptions = {}
-    ): Pipeline<TStart> {
+    ): Pipeline<TStart, TSources> {
         const runtimeDescriptor = this.lastStep.getTypeDescriptor();
         const pathSegments = getPathSegmentsFromDescriptor(runtimeDescriptor);
-        const session = new PipelineRuntimeSessionImpl<T, TStart>(
+        const session = new PipelineRuntimeSessionImpl<T, TStart, TSources>(
             this.input,
             setState,
             runtimeOptions

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,17 +1,19 @@
 import { PipelineBuilder } from './builder.js';
-import type { AddedHandler, ImmutableProps, PipelineInput, RemovedHandler, Step } from './pipeline.js';
+import type { AddedHandler, ImmutableProps, PipelineInput, PipelineSources, RemovedHandler, Step } from './pipeline.js';
 import { type TypeDescriptor, type ScalarDescriptor } from './pipeline.js';
 
 // Private class (not exported)
-class InputPipeline<T> implements PipelineInput<T>, Step {
+class InputPipeline<T> implements PipelineInput<T, {}>, Step {
     private addedHandlers: AddedHandler[] = [];
     private removedHandlers: RemovedHandler[] = [];
     private rootCollectionName: string;
     private sourceScalars: ScalarDescriptor[];
+    readonly sources: PipelineSources<{}>;
 
     constructor(rootCollectionName: string, sourceScalars: ScalarDescriptor[] = []) {
         this.rootCollectionName = rootCollectionName;
         this.sourceScalars = sourceScalars;
+        this.sources = {} as PipelineSources<{}>;
     }
 
     getTypeDescriptor(): TypeDescriptor {
@@ -64,8 +66,8 @@ export function createPipeline<TStart extends object, TRootScopeName extends str
 export function createPipeline<TStart extends object>(
     rootScopeName: string = 'items',
     sourceScalars: ScalarDescriptor[] = []
-): PipelineBuilder<TStart, TStart, [], string> {
+): PipelineBuilder<TStart, TStart, [], string, {}> {
     const start = new InputPipeline<TStart>(rootScopeName, sourceScalars);
-    return new PipelineBuilder<TStart, TStart, [], string>(start, start);
+    return new PipelineBuilder<TStart, TStart, [], string, {}>(start, start);
 }
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,6 +1,17 @@
-export interface PipelineInput<T> {
+export type PipelineSources<TSources extends Record<string, unknown>> = {
+    [K in keyof TSources]:
+        TSources[K] extends { primary: infer TSourcePrimary; sources?: infer TSourceChildren }
+            ? PipelineInput<
+                TSourcePrimary,
+                TSourceChildren extends Record<string, unknown> ? TSourceChildren : {}
+            >
+            : never;
+};
+
+export interface PipelineInput<T, TSources extends Record<string, unknown> = {}> {
     add(key: string, immutableProps: T): void;
     remove(key: string, immutableProps: T): void;
+    sources: PipelineSources<TSources>;
 }
 
 export interface PipelineRuntimeDiagnostic {
@@ -30,9 +41,8 @@ export interface PipelineRuntimeDisposeOptions {
     flush?: boolean;
 }
 
-export interface Pipeline<TStart> {
-    add(key: string, immutableProps: TStart): void;
-    remove(key: string, immutableProps: TStart): void;
+export interface Pipeline<TStart, TSources extends Record<string, unknown> = {}>
+    extends PipelineInput<TStart, TSources> {
     flush(): void;
     dispose(options?: PipelineRuntimeDisposeOptions): void;
     isDisposed(): boolean;

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -9,17 +9,25 @@ import {
 } from '../index.js';
 
 // Helper function that uses type inference to set up a test pipeline
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function createTestPipeline<TBuilder extends PipelineBuilder<any, any, any, any, any>>(
-    builderFactory: () => TBuilder
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-): [Pipeline<any, any>, () => PipelinePlainOutput<TBuilder>[]] {
+export function createTestPipeline<
+    T extends object,
+    TStart,
+    Path extends string[],
+    RootScopeName extends string,
+    TSources extends Record<string, unknown>
+>(
+    builderFactory: () => PipelineBuilder<T, TStart, Path, RootScopeName, TSources>
+): [
+    Pipeline<TStart, TSources>,
+    () => PipelinePlainOutput<PipelineBuilder<T, TStart, Path, RootScopeName, TSources>>[]
+] {
     const builder = builderFactory();
-    type RowType = PipelineOutput<TBuilder>;
+    type BuilderType = PipelineBuilder<T, TStart, Path, RootScopeName, TSources>;
+    type RowType = PipelineOutput<BuilderType>;
     const [ getState, setState ] = simulateState<KeyedArray<RowType>>([]);
     const typeDescriptor = builder.getTypeDescriptor();
     const pipeline = builder.build(setState);
-    const getOutput = (): PipelinePlainOutput<TBuilder>[] => {
+    const getOutput = (): PipelinePlainOutput<BuilderType>[] => {
         // Flush any pending batched updates before reading state
         // This ensures all changes are applied before test assertions
         pipeline.flush();

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -10,10 +10,10 @@ import {
 
 // Helper function that uses type inference to set up a test pipeline
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function createTestPipeline<TBuilder extends PipelineBuilder<any, any, any>>(
+export function createTestPipeline<TBuilder extends PipelineBuilder<any, any, any, any, any>>(
     builderFactory: () => TBuilder
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): [Pipeline<any>, () => PipelinePlainOutput<TBuilder>[]] {
+): [Pipeline<any, any>, () => PipelinePlainOutput<TBuilder>[]] {
     const builder = builderFactory();
     type RowType = PipelineOutput<TBuilder>;
     const [ getState, setState ] = simulateState<KeyedArray<RowType>>([]);

--- a/src/test/pipeline.enrich.type.test-d.ts
+++ b/src/test/pipeline.enrich.type.test-d.ts
@@ -1,0 +1,206 @@
+import { expectError, expectType } from 'tsd';
+import { createPipeline, type KeyedArray, type PipelineOutput } from '../index.js';
+
+interface Order {
+    orderId: string;
+    customerId: string;
+    regionId: string;
+    total: number;
+}
+
+interface CustomerStatus {
+    customerId: string;
+    status: string;
+}
+
+interface RegionStatus {
+    regionId: string;
+    label: string;
+}
+
+interface LoyaltyStatus {
+    customerId: string;
+    tier: string;
+}
+
+function noopSetState(): never {
+    throw new Error('not implemented');
+}
+
+// Basic enrich typing: output row keeps primary shape and adds full secondary output object.
+{
+    const customerStatusPipeline = createPipeline<CustomerStatus, 'customerStatuses'>('customerStatuses')
+        .groupBy(['customerId'], 'customerStatuses');
+
+    const ordersPipeline = createPipeline<Order, 'orders'>('orders')
+        .enrich(
+            'customerStatuses',
+            customerStatusPipeline,
+            ['customerId'],
+            'customerStatus',
+            {
+                customerId: '',
+                customerStatuses: []
+            }
+        );
+
+    type Row = PipelineOutput<typeof ordersPipeline>;
+    type CustomerStatusOutput = PipelineOutput<typeof customerStatusPipeline>;
+
+    expectType<CustomerStatusOutput>({} as Row['customerStatus']);
+    expectType<{
+        orderId: string;
+        customerId: string;
+        regionId: string;
+        total: number;
+        customerStatus: {
+            customerId: string;
+            customerStatuses: KeyedArray<{ status: string }>;
+        };
+    }>({} as Row);
+}
+
+// whenMissing must match full secondary output shape.
+{
+    const customerStatusPipeline = createPipeline<CustomerStatus, 'customerStatuses'>('customerStatuses')
+        .groupBy(['customerId'], 'customerStatuses');
+
+    expectError(
+        createPipeline<Order, 'orders'>('orders').enrich(
+            'customerStatuses',
+            customerStatusPipeline,
+            ['customerId'],
+            'customerStatus',
+            {
+                customerId: ''
+            }
+        )
+    );
+}
+
+// primaryKey members must exist on the current scope.
+{
+    const customerStatusPipeline = createPipeline<CustomerStatus, 'customerStatuses'>('customerStatuses')
+        .groupBy(['customerId'], 'customerStatuses');
+
+    expectError(
+        createPipeline<Order, 'orders'>('orders').enrich(
+            'customerStatuses',
+            customerStatusPipeline,
+            ['doesNotExist'],
+            'customerStatus'
+        )
+    );
+}
+
+// Secondary pipeline must be root-scoped (Path = []).
+{
+    type NestedSecondaryInput = {
+        rows: KeyedArray<CustomerStatus>;
+    };
+    const nestedSecondary = createPipeline<NestedSecondaryInput, 'root'>('root').in('rows');
+
+    expectError(
+        createPipeline<Order, 'orders'>('orders').enrich(
+            'customerStatuses',
+            nestedSecondary,
+            ['customerId'],
+            'customerStatus'
+        )
+    );
+}
+
+// Scoped enrich uses key properties from the scoped item type, not the root type.
+{
+    type OrdersByRegion = {
+        regionId: string;
+        orders: KeyedArray<Order>;
+    };
+
+    const customerStatusPipeline = createPipeline<CustomerStatus, 'customerStatuses'>('customerStatuses')
+        .groupBy(['customerId'], 'customerStatuses');
+
+    const scopedBuilder = createPipeline<OrdersByRegion, 'byRegion'>('byRegion')
+        .in('orders')
+        .enrich('customerStatuses', customerStatusPipeline, ['customerId'], 'customerStatus');
+
+    type Row = PipelineOutput<typeof scopedBuilder>;
+    type NestedOrder = Row['orders'][number]['value'];
+    type CustomerStatusOutput = PipelineOutput<typeof customerStatusPipeline>;
+    expectType<CustomerStatusOutput>({} as NestedOrder['customerStatus']);
+
+    expectError(
+        createPipeline<OrdersByRegion, 'byRegion'>('byRegion')
+            .in('orders')
+            .enrich('customerStatuses', customerStatusPipeline, ['foo'], 'customerStatus')
+    );
+}
+
+// build() sources typing includes sourceName mapped to secondary input type.
+{
+    const customerStatusPipeline = createPipeline<CustomerStatus, 'customerStatuses'>('customerStatuses')
+        .groupBy(['customerId'], 'customerStatuses');
+
+    const pipeline = createPipeline<Order, 'orders'>('orders')
+        .enrich('customerStatuses', customerStatusPipeline, ['customerId'], 'customerStatus')
+        .build(noopSetState);
+
+    expectType<(key: string, immutableProps: CustomerStatus) => void>(pipeline.sources.customerStatuses.add);
+    expectType<(key: string, immutableProps: CustomerStatus) => void>(pipeline.sources.customerStatuses.remove);
+}
+
+// Recursive source typing: if secondary pipeline uses enrich, nested sources are exposed.
+{
+    const loyaltyPipeline = createPipeline<LoyaltyStatus, 'loyalty'>('loyalty')
+        .groupBy(['customerId'], 'loyaltyRows');
+
+    const customerStatusWithLoyalty = createPipeline<CustomerStatus, 'customerStatuses'>('customerStatuses')
+        .groupBy(['customerId'], 'customerStatuses')
+        .enrich(
+            'loyalty',
+            loyaltyPipeline,
+            ['customerId'],
+            'loyaltySnapshot',
+            {
+                customerId: '',
+                loyalty: []
+            }
+        );
+
+    const ordersPipeline = createPipeline<Order, 'orders'>('orders')
+        .enrich('customerStatuses', customerStatusWithLoyalty, ['customerId'], 'customerStatus');
+
+    type Row = PipelineOutput<typeof ordersPipeline>;
+    type CustomerStatusOutput = PipelineOutput<typeof customerStatusWithLoyalty>;
+    type LoyaltyOutput = PipelineOutput<typeof loyaltyPipeline>;
+    expectType<CustomerStatusOutput>({} as Row['customerStatus']);
+    expectType<LoyaltyOutput>({} as Row['customerStatus']['loyaltySnapshot']);
+
+    const pipeline = ordersPipeline.build(noopSetState);
+    expectType<(key: string, immutableProps: CustomerStatus) => void>(pipeline.sources.customerStatuses.add);
+    expectType<(key: string, immutableProps: LoyaltyStatus) => void>(
+        pipeline.sources.customerStatuses.sources.loyalty.add
+    );
+}
+
+// Multiple enrich calls accumulate distinct sources and enrichment properties.
+{
+    const customerStatusPipeline = createPipeline<CustomerStatus, 'customerStatuses'>('customerStatuses')
+        .groupBy(['customerId'], 'customerStatuses');
+    const regionPipeline = createPipeline<RegionStatus, 'regions'>('regions')
+        .groupBy(['regionId'], 'regions');
+
+    const builder = createPipeline<Order, 'orders'>('orders')
+        .enrich('customerStatuses', customerStatusPipeline, ['customerId'], 'customerStatus')
+        .enrich('regions', regionPipeline, ['regionId'], 'regionStatus');
+
+    type Row = PipelineOutput<typeof builder>;
+    expectType<PipelineOutput<typeof customerStatusPipeline>>({} as Row['customerStatus']);
+    expectType<PipelineOutput<typeof regionPipeline>>({} as Row['regionStatus']);
+
+    const pipeline = builder.build(noopSetState);
+    expectType<(key: string, immutableProps: CustomerStatus) => void>(pipeline.sources.customerStatuses.add);
+    expectType<(key: string, immutableProps: RegionStatus) => void>(pipeline.sources.regions.add);
+    type SourceNames = keyof typeof pipeline.sources;
+    expectType<'customerStatuses' | 'regions'>({} as SourceNames);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add comprehensive type tests for keyed enrichment scenarios described in `docs/architecture/keyed-enrichment-primary-secondary.md`
- introduce a minimal compile-time `enrich` API on `PipelineBuilder` (runtime intentionally throws not implemented)
- thread `TSources` through `PipelineBuilder`, `PipelineInput`, and `Pipeline` types so `build().sources` is strongly typed
- tighten test helper generics to remove `any` usage flagged in review

## What changed
- Added `src/test/pipeline.enrich.type.test-d.ts` covering:
  - basic enrich output typing
  - `whenMissing` full-shape enforcement
  - invalid primary key member rejection
  - root-scoped secondary-pipeline requirement
  - scoped enrich behavior at nested paths
  - typed `pipeline.sources.<sourceName>` input signatures
  - recursive nested source typing when secondary pipelines also enrich
  - multiple enrich source accumulation
- Updated type signatures in:
  - `src/pipeline.ts` (`PipelineInput`, `Pipeline`, recursive `PipelineSources`)
  - `src/builder.ts` (5th generic `TSources`, `enrich` method signature + not-implemented runtime body)
  - `src/factory.ts` (root pipeline sources typing)
  - `src/test/helpers.ts` (strong generic extraction for `createTestPipeline` return types, no `any`)

## Validation
- `npm run build`
- `npm run test:types`
- `npm test -- --runInBand`

All pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d74a1bd8-ff48-4f03-8dc0-f5d3fc401935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d74a1bd8-ff48-4f03-8dc0-f5d3fc401935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

