### PR TITLE
Implement keyed primary/secondary enrich with runtime and type tests

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -60,6 +60,17 @@ export type PipelineOutput<TBuilder> =
 type PreserveStringLiterals<T extends readonly string[]> = T;
 
 /**
+ * Property type after {@link PipelineBuilder.enrich}: omitting `whenMissing` (or passing
+ * `undefined`) allows `undefined` when there is no matching secondary row; passing a `TSecondary`
+ * object uses that value whenever unmatched.
+ */
+export type EnrichedAs<TSecondary extends object, TWhenMissing extends TSecondary | undefined> = [
+    TWhenMissing
+] extends [undefined]
+    ? TSecondary | undefined
+    : TSecondary;
+
+/**
  * Same structure as {@link PipelineOutput} but with every {@link KeyedArray} replaced by a plain array.
  * Useful for snapshot tests and for UI models that use arrays instead of keyed rows.
  */
@@ -923,17 +934,24 @@ export class PipelineBuilder<
         TSecondaryRootScopeName extends string,
         TSecondarySources extends Record<string, unknown>,
         TPrimaryKey extends keyof NavigateToPath<T, Path> & string,
-        TAs extends string
+        TAs extends string,
+        TWhenMissing extends TSecondary | undefined = undefined
     >(
         sourceName: TSourceName,
         secondaryPipeline: PipelineBuilder<TSecondary, TSecondaryStart, [], TSecondaryRootScopeName, TSecondarySources>,
         primaryKey: PreserveStringLiterals<readonly TPrimaryKey[]>,
         as: TAs,
-        whenMissing?: TSecondary
+        whenMissing?: TWhenMissing
     ): PipelineBuilder<
         Path extends []
-            ? Expand<T & Record<TAs, TSecondary>>
-            : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TAs, TSecondary>>>,
+            ? Expand<T & Record<TAs, EnrichedAs<TSecondary, TWhenMissing>>>
+            : Expand<
+                  TransformAtPath<
+                      T,
+                      Path,
+                      NavigateToPath<T, Path> & Record<TAs, EnrichedAs<TSecondary, TWhenMissing>>
+                  >
+              >,
         TStart,
         Path,
         RootScopeName,
@@ -946,7 +964,7 @@ export class PipelineBuilder<
             this.scopeSegments as string[],
             [...primaryKey],
             as,
-            (whenMissing ?? {}) as ImmutableProps,
+            whenMissing as ImmutableProps | undefined,
             diagnostic => {
                 this.reportDiagnostic({
                     ...diagnostic,
@@ -972,8 +990,14 @@ export class PipelineBuilder<
 
         return new PipelineBuilder<
             Path extends []
-                ? Expand<T & Record<TAs, TSecondary>>
-                : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TAs, TSecondary>>>,
+                ? Expand<T & Record<TAs, EnrichedAs<TSecondary, TWhenMissing>>>
+                : Expand<
+                      TransformAtPath<
+                          T,
+                          Path,
+                          NavigateToPath<T, Path> & Record<TAs, EnrichedAs<TSecondary, TWhenMissing>>
+                      >
+                  >,
             TStart,
             Path,
             RootScopeName,

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -90,7 +90,7 @@ interface RuntimeApplyContext {
     emitDiagnostic: (diagnostic: PipelineRuntimeDiagnostic) => void;
 }
 
-class PipelineRuntimeSessionImpl<TState extends object, TStart, TSources extends Record<string, unknown> = {}>
+class PipelineRuntimeSessionImpl<TState extends object, TStart, TSources extends Record<string, unknown> = Record<never, never>>
     implements Pipeline<TStart, TSources> {
     private readonly setState: (transform: Transform<KeyedArray<TState>>) => void;
     private readonly inputPipeline: PipelineInput<TStart, TSources>;
@@ -417,7 +417,7 @@ export class PipelineBuilder<
     TStart,
     Path extends string[] = [],
     RootScopeName extends string = 'items',
-    TSources extends Record<string, unknown> = {}
+    TSources extends Record<string, unknown> = Record<never, never>
 > {
     private reportDiagnostic(diagnostic: PipelineRuntimeDiagnostic): void {
         if (this.diagnosticBridge.emit) {

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -4,6 +4,7 @@ import {
     type ImmutableProps,
     type Pipeline,
     type PipelineInput,
+    type PipelineSources,
     type PipelineRuntimeDiagnostic,
     type PipelineRuntimeDisposeOptions,
     type PipelineRuntimeOptions,
@@ -19,6 +20,7 @@ import { NavigateToPath, TransformAtPath } from './types/path.js';
 import { MinMaxAggregateStep } from './steps/min-max-aggregate.js';
 import { AverageAggregateStep } from './steps/average-aggregate.js';
 import { PickByMinMaxStep } from './steps/pick-by-min-max.js';
+import { EnrichStep } from './steps/enrich.js';
 
 // Public types
 export type KeyedArray<T> = { key: string, value: T }[];
@@ -53,7 +55,9 @@ type KeyedRecursivePlain<T> =
  * type Row = PipelineOutput<typeof builder>;
  */
 export type PipelineOutput<TBuilder> =
-    TBuilder extends PipelineBuilder<infer T, infer _S, infer _Path, infer _Root> ? T : never;
+    TBuilder extends PipelineBuilder<infer T, infer _S, infer _Path, infer _Root, infer _Sources> ? T : never;
+
+type PreserveStringLiterals<T extends readonly string[]> = T;
 
 /**
  * Same structure as {@link PipelineOutput} but with every {@link KeyedArray} replaced by a plain array.
@@ -86,9 +90,11 @@ interface RuntimeApplyContext {
     emitDiagnostic: (diagnostic: PipelineRuntimeDiagnostic) => void;
 }
 
-class PipelineRuntimeSessionImpl<TState extends object, TStart> implements Pipeline<TStart> {
+class PipelineRuntimeSessionImpl<TState extends object, TStart, TSources extends Record<string, unknown> = {}>
+    implements Pipeline<TStart, TSources> {
     private readonly setState: (transform: Transform<KeyedArray<TState>>) => void;
-    private readonly inputPipeline: PipelineInput<TStart>;
+    private readonly inputPipeline: PipelineInput<TStart, TSources>;
+    readonly sources: PipelineSources<TSources>;
     private readonly runtimeOptions: Required<Pick<PipelineRuntimeOptions, 'batchSize' | 'flushDelayMs'>> &
         Pick<PipelineRuntimeOptions, 'onDiagnostic'>;
     private pendingOperations: PendingOperation[] = [];
@@ -97,11 +103,12 @@ class PipelineRuntimeSessionImpl<TState extends object, TStart> implements Pipel
     private epoch = 1;
 
     constructor(
-        pipeline: PipelineInput<TStart>,
+        pipeline: PipelineInput<TStart, TSources>,
         setState: (transform: Transform<KeyedArray<TState>>) => void,
         runtimeOptions: PipelineRuntimeOptions
     ) {
         this.inputPipeline = pipeline;
+        this.sources = pipeline.sources;
         this.setState = setState;
         this.runtimeOptions = {
             batchSize: runtimeOptions.batchSize ?? 50,
@@ -301,6 +308,10 @@ class PipelineRuntimeSessionImpl<TState extends object, TStart> implements Pipel
         }
         console.warn(`Warning: ${diagnostic.message}`);
     }
+
+    getDiagnosticEmitter(): (diagnostic: PipelineRuntimeDiagnostic) => void {
+        return diagnostic => this.emitDiagnostic(diagnostic);
+    }
 }
 
 // Type utility to expand intersection types into a single object type for better IDE display
@@ -361,6 +372,17 @@ type CurrentScopeName<Path extends string[], RootScopeName extends string> =
         ? LastSegment
         : RootScopeName;
 
+type DeferredDiagnosticBridge = {
+    emit?: (diagnostic: PipelineRuntimeDiagnostic) => void;
+    pending: PipelineRuntimeDiagnostic[];
+};
+
+function createDeferredDiagnosticBridge(): DeferredDiagnosticBridge {
+    return {
+        pending: []
+    };
+}
+
 function compareMixedPrimitiveValues(left: number | string, right: number | string): number {
     if (typeof left === 'number' && typeof right === 'number') {
         return left - right;
@@ -390,11 +412,26 @@ function compareMixedPrimitiveValues(left: number | string, right: number | stri
  * Removes an array at the specified path from the type.
  */
 
-export class PipelineBuilder<T extends object, TStart, Path extends string[] = [], RootScopeName extends string = 'items'> {
+export class PipelineBuilder<
+    T extends object,
+    TStart,
+    Path extends string[] = [],
+    RootScopeName extends string = 'items',
+    TSources extends Record<string, unknown> = {}
+> {
+    private reportDiagnostic(diagnostic: PipelineRuntimeDiagnostic): void {
+        if (this.diagnosticBridge.emit) {
+            this.diagnosticBridge.emit(diagnostic);
+            return;
+        }
+        this.diagnosticBridge.pending.push(diagnostic);
+    }
+
     constructor(
-        private input: PipelineInput<TStart>,
+        private input: PipelineInput<TStart, TSources>,
         private lastStep: Step,
-        private scopeSegments: Path = [] as unknown as Path
+        private scopeSegments: Path = [] as unknown as Path,
+        private diagnosticBridge: DeferredDiagnosticBridge = createDeferredDiagnosticBridge()
     ) {}
 
     /**
@@ -418,7 +455,8 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<K, U>>>,
         TStart,
         Path,
-        RootScopeName
+        RootScopeName,
+        TSources
     > {
         const newStep = new DefinePropertyStep(
             this.lastStep,
@@ -427,7 +465,7 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             this.scopeSegments as string[],
             mutableProperties
         );
-        return new PipelineBuilder(this.input, newStep);
+        return new PipelineBuilder(this.input, newStep, [] as unknown as Path, this.diagnosticBridge);
     }
 
     dropProperty<K extends keyof NavigateToPath<T, Path>>(propertyName: K): PipelineBuilder<
@@ -436,14 +474,15 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             : Expand<TransformAtPath<T, Path, Expand<Omit<NavigateToPath<T, Path>, K>>>>,
         TStart,
         Path,
-        RootScopeName
+        RootScopeName,
+        TSources
     > {
         const newStep = new DropPropertyStep<NavigateToPath<T, Path>, K>(
             this.lastStep,
             propertyName,
             this.scopeSegments as string[]
         );
-        return new PipelineBuilder(this.input, newStep);
+        return new PipelineBuilder(this.input, newStep, [] as unknown as Path, this.diagnosticBridge);
     }
 
     groupBy<K extends keyof NavigateToPath<T, Path>, ArrayName extends string>(
@@ -455,7 +494,8 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             : Expand<TransformAtPath<T, Path, { [P in K]: NavigateToPath<T, Path>[P] } & { [P in CurrentScopeName<Path, RootScopeName>]: KeyedArray<{ [Q in Exclude<keyof NavigateToPath<T, Path>, K>]: NavigateToPath<T, Path>[Q] }> }>>,
         TStart,
         Path,
-        Path extends [] ? ArrayName : RootScopeName
+        Path extends [] ? ArrayName : RootScopeName,
+        TSources
     > {
         const descriptor = this.lastStep.getTypeDescriptor();
         const inferredChildArrayName = this.scopeSegments.length > 0
@@ -469,7 +509,7 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             inferredChildArrayName,
             this.scopeSegments as string[]
         );
-        return new PipelineBuilder(this.input, newStep);
+        return new PipelineBuilder(this.input, newStep, [] as unknown as Path, this.diagnosticBridge);
     }
 
     /*
@@ -539,7 +579,8 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<PropName, TAggregate>>>,
         TStart,
         Path,
-        RootScopeName
+        RootScopeName,
+        TSources
     > {
         const fullSegmentPath = [...this.scopeSegments, arrayName];
         const newStep = new CommutativeAggregateStep(
@@ -552,7 +593,7 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             },
             propertyToAggregate
         );
-        return new PipelineBuilder(this.input, newStep);
+        return new PipelineBuilder(this.input, newStep, [] as unknown as Path, this.diagnosticBridge);
     }
 
     /**
@@ -580,7 +621,8 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TPropName, number>>>,
         TStart,
         Path,
-        RootScopeName
+        RootScopeName,
+        TSources
     > {
         return this.commutativeAggregate(
             arrayName,
@@ -622,7 +664,8 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TPropName, number>>>,
         TStart,
         Path,
-        RootScopeName
+        RootScopeName,
+        TSources
     > {
         return this.commutativeAggregate(
             arrayName,
@@ -657,7 +700,8 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TPropName, number | undefined>>>,
         TStart,
         Path,
-        RootScopeName
+        RootScopeName,
+        TSources
     > {
         const fullSegmentPath = [...this.scopeSegments, arrayName];
         const newStep = new MinMaxAggregateStep(
@@ -667,7 +711,7 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             propertyName,
             (left, right) => left - right
         );
-        return new PipelineBuilder(this.input, newStep);
+        return new PipelineBuilder(this.input, newStep, [] as unknown as Path, this.diagnosticBridge);
     }
     
     /**
@@ -695,7 +739,8 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TPropName, number | undefined>>>,
         TStart,
         Path,
-        RootScopeName
+        RootScopeName,
+        TSources
     > {
         const fullSegmentPath = [...this.scopeSegments, arrayName];
         const newStep = new MinMaxAggregateStep(
@@ -705,7 +750,7 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             propertyName,
             (left, right) => right - left
         );
-        return new PipelineBuilder(this.input, newStep);
+        return new PipelineBuilder(this.input, newStep, [] as unknown as Path, this.diagnosticBridge);
     }
     
     /**
@@ -733,7 +778,8 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TPropName, number | undefined>>>,
         TStart,
         Path,
-        RootScopeName
+        RootScopeName,
+        TSources
     > {
         const fullSegmentPath = [...this.scopeSegments, arrayName];
         const newStep = new AverageAggregateStep(
@@ -742,7 +788,7 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             outputProperty,
             propertyName
         );
-        return new PipelineBuilder(this.input, newStep);
+        return new PipelineBuilder(this.input, newStep, [] as unknown as Path, this.diagnosticBridge);
     }
     
     /**
@@ -771,7 +817,8 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TPropName, ArrayItemAtCurrentPath<T, Path, ArrayName> | undefined>>>,
         TStart,
         Path,
-        RootScopeName
+        RootScopeName,
+        TSources
     > {
         const fullSegmentPath = [...this.scopeSegments, arrayName];
         const newStep = new PickByMinMaxStep(
@@ -781,7 +828,7 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             propertyName,
             compareMixedPrimitiveValues
         );
-        return new PipelineBuilder(this.input, newStep);
+        return new PipelineBuilder(this.input, newStep, [] as unknown as Path, this.diagnosticBridge);
     }
     
     /**
@@ -810,7 +857,8 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TPropName, ArrayItemAtCurrentPath<T, Path, ArrayName> | undefined>>>,
         TStart,
         Path,
-        RootScopeName
+        RootScopeName,
+        TSources
     > {
         const fullSegmentPath = [...this.scopeSegments, arrayName];
         const newStep = new PickByMinMaxStep(
@@ -820,7 +868,7 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
             propertyName,
             (left, right) => compareMixedPrimitiveValues(right, left)
         );
-        return new PipelineBuilder(this.input, newStep);
+        return new PipelineBuilder(this.input, newStep, [] as unknown as Path, this.diagnosticBridge);
     }
     
     /**
@@ -832,11 +880,12 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
      */
     in<NewPath extends string[]>(
         ...pathSegments: NewPath
-    ): PipelineBuilder<T, TStart, [...Path, ...NewPath], RootScopeName> {
-        return new PipelineBuilder<T, TStart, [...Path, ...NewPath], RootScopeName>(
+    ): PipelineBuilder<T, TStart, [...Path, ...NewPath], RootScopeName, TSources> {
+        return new PipelineBuilder<T, TStart, [...Path, ...NewPath], RootScopeName, TSources>(
             this.input,
             this.lastStep,
-            [...this.scopeSegments, ...pathSegments] as [...Path, ...NewPath]
+            [...this.scopeSegments, ...pathSegments] as [...Path, ...NewPath],
+            this.diagnosticBridge
         );
     }
 
@@ -857,14 +906,79 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
     filter(
         predicate: (item: NavigateToPath<T, Path>) => boolean,
         mutableProperties: string[] = []
-    ): PipelineBuilder<T, TStart, Path, RootScopeName> {
+    ): PipelineBuilder<T, TStart, Path, RootScopeName, TSources> {
         const newStep = new FilterStep<NavigateToPath<T, Path>>(
             this.lastStep,
             predicate as (item: unknown) => boolean,
             this.scopeSegments as string[],
             mutableProperties
         );
-        return new PipelineBuilder(this.input, newStep, this.scopeSegments);
+        return new PipelineBuilder(this.input, newStep, this.scopeSegments, this.diagnosticBridge);
+    }
+
+    enrich<
+        TSourceName extends string,
+        TSecondary extends object,
+        TSecondaryStart extends object,
+        TSecondaryRootScopeName extends string,
+        TSecondarySources extends Record<string, unknown>,
+        TPrimaryKey extends keyof NavigateToPath<T, Path> & string,
+        TAs extends string
+    >(
+        sourceName: TSourceName,
+        secondaryPipeline: PipelineBuilder<TSecondary, TSecondaryStart, [], TSecondaryRootScopeName, TSecondarySources>,
+        primaryKey: PreserveStringLiterals<readonly TPrimaryKey[]>,
+        as: TAs,
+        whenMissing?: TSecondary
+    ): PipelineBuilder<
+        Path extends []
+            ? Expand<T & Record<TAs, TSecondary>>
+            : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TAs, TSecondary>>>,
+        TStart,
+        Path,
+        RootScopeName,
+        TSources & Record<TSourceName, { primary: TSecondaryStart; sources: TSecondarySources }>
+    > {
+        type NewSources = TSources & Record<TSourceName, { primary: TSecondaryStart; sources: TSecondarySources }>;
+        const newStep = new EnrichStep(
+            this.lastStep,
+            secondaryPipeline.lastStep,
+            this.scopeSegments as string[],
+            [...primaryKey],
+            as,
+            (whenMissing ?? {}) as ImmutableProps,
+            diagnostic => {
+                this.reportDiagnostic({
+                    ...diagnostic,
+                    operationType: 'modify'
+                });
+            }
+        );
+
+        const mergedSources = {
+            ...(this.input.sources as Record<string, unknown>),
+            [sourceName]: secondaryPipeline.input
+        } as PipelineSources<NewSources>;
+
+        const inputWithSources: PipelineInput<TStart, NewSources> = {
+            add: (key: string, immutableProps: TStart) => {
+                this.input.add(key, immutableProps);
+            },
+            remove: (key: string, immutableProps: TStart) => {
+                this.input.remove(key, immutableProps);
+            },
+            sources: mergedSources
+        };
+
+        return new PipelineBuilder<
+            Path extends []
+                ? Expand<T & Record<TAs, TSecondary>>
+                : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TAs, TSecondary>>>,
+            TStart,
+            Path,
+            RootScopeName,
+            NewSources
+        >(inputWithSources, newStep, this.scopeSegments, this.diagnosticBridge);
     }
 
     getTypeDescriptor(): TypeDescriptor {
@@ -878,10 +992,24 @@ export class PipelineBuilder<T extends object, TStart, Path extends string[] = [
     build(
         setState: (transform: Transform<KeyedArray<T>>) => void,
         runtimeOptions: PipelineRuntimeOptions = {}
-    ): Pipeline<TStart> {
+    ): Pipeline<TStart, TSources> {
+        this.diagnosticBridge.emit = diagnostic => {
+            if (runtimeOptions.onDiagnostic) {
+                runtimeOptions.onDiagnostic(diagnostic);
+                return;
+            }
+            console.warn(`Warning: ${diagnostic.message}`);
+        };
+        if (this.diagnosticBridge.pending.length > 0) {
+            for (const diagnostic of this.diagnosticBridge.pending) {
+                this.diagnosticBridge.emit(diagnostic);
+            }
+            this.diagnosticBridge.pending = [];
+        }
+
         const runtimeDescriptor = this.lastStep.getTypeDescriptor();
         const pathSegments = getPathSegmentsFromDescriptor(runtimeDescriptor);
-        const session = new PipelineRuntimeSessionImpl<T, TStart>(
+        const session = new PipelineRuntimeSessionImpl<T, TStart, TSources>(
             this.input,
             setState,
             runtimeOptions

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -319,10 +319,6 @@ class PipelineRuntimeSessionImpl<TState extends object, TStart, TSources extends
         }
         console.warn(`Warning: ${diagnostic.message}`);
     }
-
-    getDiagnosticEmitter(): (diagnostic: PipelineRuntimeDiagnostic) => void {
-        return diagnostic => this.emitDiagnostic(diagnostic);
-    }
 }
 
 // Type utility to expand intersection types into a single object type for better IDE display

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -3,17 +3,17 @@ import type { AddedHandler, ImmutableProps, PipelineInput, PipelineSources, Remo
 import { type TypeDescriptor, type ScalarDescriptor } from './pipeline.js';
 
 // Private class (not exported)
-class InputPipeline<T> implements PipelineInput<T, {}>, Step {
+class InputPipeline<T> implements PipelineInput<T, Record<never, never>>, Step {
     private addedHandlers: AddedHandler[] = [];
     private removedHandlers: RemovedHandler[] = [];
     private rootCollectionName: string;
     private sourceScalars: ScalarDescriptor[];
-    readonly sources: PipelineSources<{}>;
+    readonly sources: PipelineSources<Record<never, never>>;
 
     constructor(rootCollectionName: string, sourceScalars: ScalarDescriptor[] = []) {
         this.rootCollectionName = rootCollectionName;
         this.sourceScalars = sourceScalars;
-        this.sources = {} as PipelineSources<{}>;
+        this.sources = {} as PipelineSources<Record<never, never>>;
     }
 
     getTypeDescriptor(): TypeDescriptor {
@@ -59,9 +59,9 @@ function createSourceInputFacade<
     sourceSpec: TSourceSpec
 ): PipelineInput<
     TSourceSpec['primary'] & object,
-    TSourceSpec['sources'] extends Record<string, unknown> ? TSourceSpec['sources'] : {}
+    TSourceSpec['sources'] extends Record<string, unknown> ? TSourceSpec['sources'] : Record<never, never>
 > {
-    type TChildSources = TSourceSpec['sources'] extends Record<string, unknown> ? TSourceSpec['sources'] : {};
+    type TChildSources = TSourceSpec['sources'] extends Record<string, unknown> ? TSourceSpec['sources'] : Record<never, never>;
     const childSources = (sourceSpec.sources ?? {}) as TChildSources;
     const nestedEntries = Object.entries(childSources).map(([name, value]) => {
         return [name, createSourceInputFacade(value as { primary: unknown; sources?: Record<string, unknown> })];
@@ -109,8 +109,8 @@ export function createPipeline<TStart extends object, TRootScopeName extends str
 export function createPipeline<TStart extends object>(
     rootScopeName: string = 'items',
     sourceScalars: ScalarDescriptor[] = []
-): PipelineBuilder<TStart, TStart, [], string, {}> {
+): PipelineBuilder<TStart, TStart, [], string, Record<never, never>> {
     const start = new InputPipeline<TStart>(rootScopeName, sourceScalars);
-    return new PipelineBuilder<TStart, TStart, [], string, {}>(start, start);
+    return new PipelineBuilder<TStart, TStart, [], string, Record<never, never>>(start, start);
 }
 

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,4 +1,4 @@
-import { PipelineBuilder, type KeyedArray } from './builder.js';
+import { PipelineBuilder } from './builder.js';
 import type { AddedHandler, ImmutableProps, PipelineInput, PipelineSources, RemovedHandler, Step } from './pipeline.js';
 import { type TypeDescriptor, type ScalarDescriptor } from './pipeline.js';
 
@@ -51,49 +51,6 @@ class InputPipeline<T> implements PipelineInput<T, Record<never, never>>, Step {
         // No modifications at input level
     }
 
-}
-
-function createSourceInputFacade<
-    TSourceSpec extends { primary: unknown; sources?: Record<string, unknown> }
->(
-    sourceSpec: TSourceSpec
-): PipelineInput<
-    TSourceSpec['primary'] & object,
-    TSourceSpec['sources'] extends Record<string, unknown> ? TSourceSpec['sources'] : Record<never, never>
-> {
-    type TChildSources = TSourceSpec['sources'] extends Record<string, unknown> ? TSourceSpec['sources'] : Record<never, never>;
-    const childSources = (sourceSpec.sources ?? {}) as TChildSources;
-    const nestedEntries = Object.entries(childSources).map(([name, value]) => {
-        return [name, createSourceInputFacade(value as { primary: unknown; sources?: Record<string, unknown> })];
-    });
-    const nested = Object.fromEntries(nestedEntries) as PipelineSources<TChildSources>;
-
-    const state: KeyedArray<TSourceSpec['primary'] & object> = [];
-
-    return {
-        add: (_key: string, immutableProps: TSourceSpec['primary'] & object) => {
-            state.push({ key: '', value: immutableProps });
-        },
-        remove: (_key: string, immutableProps: TSourceSpec['primary'] & object) => {
-            const index = state.findIndex(item => item.value === immutableProps);
-            if (index >= 0) {
-                state.splice(index, 1);
-            }
-        },
-        sources: nested
-    };
-}
-
-export function createSourceInputs<TSources extends Record<string, unknown>>(
-    sourceSpecs: TSources
-): PipelineSources<TSources> {
-    const entries = Object.entries(sourceSpecs).map(([sourceName, sourceSpec]) => {
-        return [
-            sourceName,
-            createSourceInputFacade(sourceSpec as { primary: unknown; sources?: Record<string, unknown> })
-        ];
-    });
-    return Object.fromEntries(entries) as PipelineSources<TSources>;
 }
 
 export function createPipeline<TStart extends object>(): PipelineBuilder<TStart, TStart, [], 'items'>;

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,17 +1,19 @@
-import { PipelineBuilder } from './builder.js';
-import type { AddedHandler, ImmutableProps, PipelineInput, RemovedHandler, Step } from './pipeline.js';
+import { PipelineBuilder, type KeyedArray } from './builder.js';
+import type { AddedHandler, ImmutableProps, PipelineInput, PipelineSources, RemovedHandler, Step } from './pipeline.js';
 import { type TypeDescriptor, type ScalarDescriptor } from './pipeline.js';
 
 // Private class (not exported)
-class InputPipeline<T> implements PipelineInput<T>, Step {
+class InputPipeline<T> implements PipelineInput<T, {}>, Step {
     private addedHandlers: AddedHandler[] = [];
     private removedHandlers: RemovedHandler[] = [];
     private rootCollectionName: string;
     private sourceScalars: ScalarDescriptor[];
+    readonly sources: PipelineSources<{}>;
 
     constructor(rootCollectionName: string, sourceScalars: ScalarDescriptor[] = []) {
         this.rootCollectionName = rootCollectionName;
         this.sourceScalars = sourceScalars;
+        this.sources = {} as PipelineSources<{}>;
     }
 
     getTypeDescriptor(): TypeDescriptor {
@@ -51,6 +53,49 @@ class InputPipeline<T> implements PipelineInput<T>, Step {
 
 }
 
+function createSourceInputFacade<
+    TSourceSpec extends { primary: unknown; sources?: Record<string, unknown> }
+>(
+    sourceSpec: TSourceSpec
+): PipelineInput<
+    TSourceSpec['primary'] & object,
+    TSourceSpec['sources'] extends Record<string, unknown> ? TSourceSpec['sources'] : {}
+> {
+    type TChildSources = TSourceSpec['sources'] extends Record<string, unknown> ? TSourceSpec['sources'] : {};
+    const childSources = (sourceSpec.sources ?? {}) as TChildSources;
+    const nestedEntries = Object.entries(childSources).map(([name, value]) => {
+        return [name, createSourceInputFacade(value as { primary: unknown; sources?: Record<string, unknown> })];
+    });
+    const nested = Object.fromEntries(nestedEntries) as PipelineSources<TChildSources>;
+
+    const state: KeyedArray<TSourceSpec['primary'] & object> = [];
+
+    return {
+        add: (_key: string, immutableProps: TSourceSpec['primary'] & object) => {
+            state.push({ key: '', value: immutableProps });
+        },
+        remove: (_key: string, immutableProps: TSourceSpec['primary'] & object) => {
+            const index = state.findIndex(item => item.value === immutableProps);
+            if (index >= 0) {
+                state.splice(index, 1);
+            }
+        },
+        sources: nested
+    };
+}
+
+export function createSourceInputs<TSources extends Record<string, unknown>>(
+    sourceSpecs: TSources
+): PipelineSources<TSources> {
+    const entries = Object.entries(sourceSpecs).map(([sourceName, sourceSpec]) => {
+        return [
+            sourceName,
+            createSourceInputFacade(sourceSpec as { primary: unknown; sources?: Record<string, unknown> })
+        ];
+    });
+    return Object.fromEntries(entries) as PipelineSources<TSources>;
+}
+
 export function createPipeline<TStart extends object>(): PipelineBuilder<TStart, TStart, [], 'items'>;
 export function createPipeline<TStart extends object, TRootScopeName extends string>(
     rootScopeName: TRootScopeName,
@@ -64,8 +109,8 @@ export function createPipeline<TStart extends object, TRootScopeName extends str
 export function createPipeline<TStart extends object>(
     rootScopeName: string = 'items',
     sourceScalars: ScalarDescriptor[] = []
-): PipelineBuilder<TStart, TStart, [], string> {
+): PipelineBuilder<TStart, TStart, [], string, {}> {
     const start = new InputPipeline<TStart>(rootScopeName, sourceScalars);
-    return new PipelineBuilder<TStart, TStart, [], string>(start, start);
+    return new PipelineBuilder<TStart, TStart, [], string, {}>(start, start);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,14 @@ export type {
     PipelineRuntimeDisposeOptions,
     PipelineRuntimeOptions
 } from './pipeline.js';
-export type { KeyedArray, Transform, PipelineOutput, PipelinePlainOutput, PipelinePlainOutputShape } from './builder.js';
+export type {
+    KeyedArray,
+    Transform,
+    PipelineOutput,
+    PipelinePlainOutput,
+    PipelinePlainOutputShape,
+    EnrichedAs
+} from './builder.js';
 export { toPipelinePlainOutput } from './plain-output.js';
 export { PipelineBuilder } from './builder.js';
 export { createPipeline } from './factory.js';

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -24,7 +24,6 @@ export interface PipelineRuntimeDiagnostic {
         | 'missing_parent_remove_dropped'
         | 'missing_parent_modify_dropped'
         | 'missing_item_modify_dropped'
-        | 'unknown_secondary_source_dropped'
         | 'enrich_key_arity_mismatch'
         | 'enrich_invalid_primary_key_property'
         | 'enrich_secondary_collection_key_missing';

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,14 +1,16 @@
+type EmptySources = Record<never, never>;
+
 export type PipelineSources<TSources extends Record<string, unknown>> = {
     [K in keyof TSources]:
         TSources[K] extends { primary: infer TSourcePrimary; sources?: infer TSourceChildren }
             ? PipelineInput<
                 TSourcePrimary,
-                TSourceChildren extends Record<string, unknown> ? TSourceChildren : {}
+                TSourceChildren extends Record<string, unknown> ? TSourceChildren : EmptySources
             >
             : never;
 };
 
-export interface PipelineInput<T, TSources extends Record<string, unknown> = {}> {
+export interface PipelineInput<T, TSources extends Record<string, unknown> = EmptySources> {
     add(key: string, immutableProps: T): void;
     remove(key: string, immutableProps: T): void;
     sources: PipelineSources<TSources>;
@@ -45,7 +47,7 @@ export interface PipelineRuntimeDisposeOptions {
     flush?: boolean;
 }
 
-export interface Pipeline<TStart, TSources extends Record<string, unknown> = {}>
+export interface Pipeline<TStart, TSources extends Record<string, unknown> = EmptySources>
     extends PipelineInput<TStart, TSources> {
     flush(): void;
     dispose(options?: PipelineRuntimeDisposeOptions): void;

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,6 +1,17 @@
-export interface PipelineInput<T> {
+export type PipelineSources<TSources extends Record<string, unknown>> = {
+    [K in keyof TSources]:
+        TSources[K] extends { primary: infer TSourcePrimary; sources?: infer TSourceChildren }
+            ? PipelineInput<
+                TSourcePrimary,
+                TSourceChildren extends Record<string, unknown> ? TSourceChildren : {}
+            >
+            : never;
+};
+
+export interface PipelineInput<T, TSources extends Record<string, unknown> = {}> {
     add(key: string, immutableProps: T): void;
     remove(key: string, immutableProps: T): void;
+    sources: PipelineSources<TSources>;
 }
 
 export interface PipelineRuntimeDiagnostic {
@@ -10,7 +21,11 @@ export interface PipelineRuntimeDiagnostic {
         | 'missing_parent_add_dropped'
         | 'missing_parent_remove_dropped'
         | 'missing_parent_modify_dropped'
-        | 'missing_item_modify_dropped';
+        | 'missing_item_modify_dropped'
+        | 'unknown_secondary_source_dropped'
+        | 'enrich_key_arity_mismatch'
+        | 'enrich_invalid_primary_key_property'
+        | 'enrich_secondary_collection_key_missing';
     message: string;
     operationType?: 'add' | 'remove' | 'modify';
     segmentPath?: string[];
@@ -30,9 +45,8 @@ export interface PipelineRuntimeDisposeOptions {
     flush?: boolean;
 }
 
-export interface Pipeline<TStart> {
-    add(key: string, immutableProps: TStart): void;
-    remove(key: string, immutableProps: TStart): void;
+export interface Pipeline<TStart, TSources extends Record<string, unknown> = {}>
+    extends PipelineInput<TStart, TSources> {
     flush(): void;
     dispose(options?: PipelineRuntimeDisposeOptions): void;
     isDisposed(): boolean;

--- a/src/steps/enrich.ts
+++ b/src/steps/enrich.ts
@@ -20,7 +20,13 @@ function stableSerialize(value: unknown): string {
 }
 
 function valuesEqual(left: unknown, right: unknown): boolean {
-    return stableSerialize(left) === stableSerialize(right);
+    try {
+        return stableSerialize(left) === stableSerialize(right);
+    } catch {
+        // If either value cannot be serialized (e.g., circular reference, BigInt),
+        // treat them as unequal rather than crashing the pipeline.
+        return false;
+    }
 }
 
 type EmitDiagnostic = (diagnostic: {

--- a/src/steps/enrich.ts
+++ b/src/steps/enrich.ts
@@ -58,7 +58,7 @@ export class EnrichStep implements Step {
         private readonly scopeSegments: string[],
         private readonly primaryKey: string[],
         private readonly asProperty: string,
-        private readonly whenMissing: ImmutableProps,
+        private readonly whenMissing: ImmutableProps | undefined,
         private readonly emitDiagnostic?: EmitDiagnostic
     ) {
         this.input.onAdded(this.scopeSegments, (keyPath, key, immutableProps) => {
@@ -222,7 +222,7 @@ export class EnrichStep implements Step {
         return stableSerialize(tuple);
     }
 
-    private resolveEnrichmentFromJoinHash(joinHash: string | null): ImmutableProps {
+    private resolveEnrichmentFromJoinHash(joinHash: string | null): ImmutableProps | undefined {
         if (joinHash === null) {
             return this.whenMissing;
         }
@@ -230,7 +230,7 @@ export class EnrichStep implements Step {
         return matched?.immutableProps ?? this.whenMissing;
     }
 
-    private resolveEnrichmentForPrimary(primaryRow: ImmutableProps): ImmutableProps {
+    private resolveEnrichmentForPrimary(primaryRow: ImmutableProps): ImmutableProps | undefined {
         const joinHash = this.primaryJoinFromPrimaryRow(primaryRow);
         return this.resolveEnrichmentFromJoinHash(joinHash);
     }

--- a/src/steps/enrich.ts
+++ b/src/steps/enrich.ts
@@ -41,7 +41,8 @@ interface PrimaryRecord {
     keyPath: string[];
     primaryKey: string;
     immutableProps: ImmutableProps;
-    joinKeyHash: string;
+    /** Serialized join tuple when indexed; null when the row has no valid join (same as add skipped). */
+    joinKeyHash: string | null;
 }
 
 interface SecondaryRecord {
@@ -73,6 +74,13 @@ export class EnrichStep implements Step {
         this.input.onRemoved(this.scopeSegments, (keyPath, key, immutableProps) => {
             this.handlePrimaryRemoved(keyPath, key, immutableProps);
         });
+
+        const primaryKeyColumns = new Set(this.primaryKey);
+        for (const propertyName of primaryKeyColumns) {
+            this.input.onModified(this.scopeSegments, propertyName, (keyPath, key, _oldValue, newValue) => {
+                this.handlePrimaryJoinKeyPropertyModified(keyPath, key, propertyName, newValue);
+            });
+        }
 
         const secondaryDescriptor = this.secondary.getTypeDescriptor();
         const secondaryPaths = getAllPathSegmentsFromDescriptor(secondaryDescriptor);
@@ -268,6 +276,9 @@ export class EnrichStep implements Step {
             return;
         }
         this.primaryRowsById.delete(id);
+        if (existing.joinKeyHash === null) {
+            return;
+        }
         const ids = this.primaryIdsByJoinKey.get(existing.joinKeyHash);
         if (!ids) {
             return;
@@ -276,6 +287,63 @@ export class EnrichStep implements Step {
         if (ids.size === 0) {
             this.primaryIdsByJoinKey.delete(existing.joinKeyHash);
         }
+    }
+
+    private handlePrimaryJoinKeyPropertyModified(
+        keyPath: string[],
+        key: string,
+        propertyName: string,
+        newValue: unknown
+    ): void {
+        const id = this.primaryId(keyPath, key);
+        const record = this.primaryRowsById.get(id);
+        if (!record) {
+            return;
+        }
+
+        const mergedRow = { ...record.immutableProps, [propertyName]: newValue };
+        const newJoinHash = this.primaryJoinFromPrimaryRow(mergedRow);
+        const oldJoinHash = record.joinKeyHash;
+
+        record.immutableProps = mergedRow;
+
+        if (oldJoinHash === newJoinHash) {
+            return;
+        }
+
+        const oldEnrichment = this.resolveEnrichmentFromJoinHash(oldJoinHash);
+        const newEnrichment = this.resolveEnrichmentFromJoinHash(newJoinHash);
+
+        if (oldJoinHash !== null) {
+            const oldSet = this.primaryIdsByJoinKey.get(oldJoinHash);
+            if (oldSet) {
+                oldSet.delete(id);
+                if (oldSet.size === 0) {
+                    this.primaryIdsByJoinKey.delete(oldJoinHash);
+                }
+            }
+        }
+
+        if (newJoinHash !== null) {
+            record.joinKeyHash = newJoinHash;
+            let ids = this.primaryIdsByJoinKey.get(newJoinHash);
+            if (!ids) {
+                ids = new Set<string>();
+                this.primaryIdsByJoinKey.set(newJoinHash, ids);
+            }
+            ids.add(id);
+        } else {
+            record.joinKeyHash = null;
+        }
+
+        const previous = oldEnrichment ?? this.whenMissing;
+        const next = newEnrichment ?? this.whenMissing;
+        if (valuesEqual(previous, next)) {
+            return;
+        }
+        this.modifiedHandlers.forEach(handler => {
+            handler(record.keyPath, record.primaryKey, previous, next);
+        });
     }
 
     private handleSecondaryAddedAtPath(

--- a/src/steps/enrich.ts
+++ b/src/steps/enrich.ts
@@ -25,7 +25,6 @@ function valuesEqual(left: unknown, right: unknown): boolean {
 
 type EmitDiagnostic = (diagnostic: {
     code:
-        | 'unknown_secondary_source_dropped'
         | 'enrich_key_arity_mismatch'
         | 'enrich_invalid_primary_key_property'
         | 'enrich_secondary_collection_key_missing';

--- a/src/steps/enrich.ts
+++ b/src/steps/enrich.ts
@@ -1,0 +1,556 @@
+import type {
+    AddedHandler,
+    DescriptorNode,
+    ImmutableProps,
+    ModifiedHandler,
+    RemovedHandler,
+    Step,
+    TypeDescriptor
+} from '../pipeline.js';
+import { appendMutableIfMissing, appendObjectIfMissing } from '../util/descriptor-transform.js';
+import { pathsMatch } from '../util/path.js';
+import { getPathSegmentsFromDescriptor as getAllPathSegmentsFromDescriptor } from '../pipeline.js';
+
+function keyPathHash(keyPath: string[]): string {
+    return keyPath.join('::');
+}
+
+function stableSerialize(value: unknown): string {
+    return JSON.stringify(value);
+}
+
+function valuesEqual(left: unknown, right: unknown): boolean {
+    return stableSerialize(left) === stableSerialize(right);
+}
+
+type EmitDiagnostic = (diagnostic: {
+    code:
+        | 'unknown_secondary_source_dropped'
+        | 'enrich_key_arity_mismatch'
+        | 'enrich_invalid_primary_key_property'
+        | 'enrich_secondary_collection_key_missing';
+    message: string;
+}) => void;
+
+interface PrimaryRecord {
+    keyPath: string[];
+    primaryKey: string;
+    immutableProps: ImmutableProps;
+    joinKeyHash: string;
+}
+
+interface SecondaryRecord {
+    keyPath: string[];
+    immutableProps: ImmutableProps;
+}
+
+type KeyedArray<T> = { key: string; value: T }[];
+
+export class EnrichStep implements Step {
+    private readonly primaryRowsById = new Map<string, PrimaryRecord>();
+    private readonly primaryIdsByJoinKey = new Map<string, Set<string>>();
+    private readonly secondaryRowByJoinKey = new Map<string, SecondaryRecord>();
+    private readonly modifiedHandlers: ModifiedHandler[] = [];
+    private secondaryState: KeyedArray<ImmutableProps> = [];
+
+    constructor(
+        private readonly input: Step,
+        private readonly secondary: Step,
+        private readonly scopeSegments: string[],
+        private readonly primaryKey: string[],
+        private readonly asProperty: string,
+        private readonly whenMissing: ImmutableProps,
+        private readonly emitDiagnostic?: EmitDiagnostic
+    ) {
+        this.input.onAdded(this.scopeSegments, (keyPath, key, immutableProps) => {
+            this.handlePrimaryAdded(keyPath, key, immutableProps);
+        });
+        this.input.onRemoved(this.scopeSegments, (keyPath, key, immutableProps) => {
+            this.handlePrimaryRemoved(keyPath, key, immutableProps);
+        });
+
+        const secondaryDescriptor = this.secondary.getTypeDescriptor();
+        const secondaryPaths = getAllPathSegmentsFromDescriptor(secondaryDescriptor);
+        const mutableProperties = collectAllMutableProperties(secondaryDescriptor);
+
+        for (const segmentPath of secondaryPaths) {
+            this.secondary.onAdded(segmentPath, (keyPath, key, immutableProps) => {
+                this.handleSecondaryAddedAtPath(segmentPath, keyPath, key, immutableProps);
+            });
+            this.secondary.onRemoved(segmentPath, (keyPath, key, immutableProps) => {
+                this.handleSecondaryRemovedAtPath(segmentPath, keyPath, key, immutableProps);
+            });
+            for (const propertyName of mutableProperties) {
+                this.secondary.onModified(segmentPath, propertyName, (keyPath, key, _oldValue, newValue) => {
+                    this.handleSecondaryModifiedAtPath(segmentPath, keyPath, key, propertyName, newValue);
+                });
+            }
+        }
+    }
+
+    getTypeDescriptor(): TypeDescriptor {
+        const inputDescriptor = this.input.getTypeDescriptor();
+        const secondaryDescriptor = this.secondary.getTypeDescriptor();
+
+        const secondaryRoot: DescriptorNode = {
+            arrays: secondaryDescriptor.arrays,
+            collectionKey: secondaryDescriptor.collectionKey,
+            scalars: secondaryDescriptor.scalars,
+            objects: secondaryDescriptor.objects,
+            mutableProperties: secondaryDescriptor.mutableProperties
+        };
+
+        if (this.scopeSegments.length === 0) {
+            const withObject = appendObjectIfMissing(inputDescriptor, {
+                name: this.asProperty,
+                type: secondaryRoot
+            });
+            return appendMutableIfMissing(withObject, this.asProperty) as TypeDescriptor;
+        }
+
+        const atScope = this.addObjectAtPath(inputDescriptor, this.scopeSegments, {
+            name: this.asProperty,
+            type: secondaryRoot
+        });
+        return {
+            ...appendMutableIfMissing(atScope, this.asProperty),
+            rootCollectionName: inputDescriptor.rootCollectionName
+        };
+    }
+
+    onAdded(pathSegments: string[], handler: AddedHandler): void {
+        if (pathsMatch(pathSegments, this.scopeSegments)) {
+            this.input.onAdded(pathSegments, (keyPath, key, immutableProps) => {
+                const enrichedValue = this.resolveEnrichmentForPrimary(immutableProps);
+                handler(keyPath, key, {
+                    ...immutableProps,
+                    [this.asProperty]: enrichedValue
+                });
+            });
+            return;
+        }
+        this.input.onAdded(pathSegments, handler);
+    }
+
+    onRemoved(pathSegments: string[], handler: RemovedHandler): void {
+        if (pathsMatch(pathSegments, this.scopeSegments)) {
+            this.input.onRemoved(pathSegments, (keyPath, key, immutableProps) => {
+                const enrichedValue = this.resolveEnrichmentForPrimary(immutableProps);
+                handler(keyPath, key, {
+                    ...immutableProps,
+                    [this.asProperty]: enrichedValue
+                });
+            });
+            return;
+        }
+        this.input.onRemoved(pathSegments, handler);
+    }
+
+    onModified(pathSegments: string[], propertyName: string, handler: ModifiedHandler): void {
+        if (pathsMatch(pathSegments, this.scopeSegments) && propertyName === this.asProperty) {
+            this.modifiedHandlers.push(handler);
+        }
+        this.input.onModified(pathSegments, propertyName, handler);
+    }
+
+    private addObjectAtPath(
+        descriptor: DescriptorNode,
+        path: string[],
+        objectDesc: { name: string; type: DescriptorNode }
+    ): DescriptorNode {
+        if (path.length === 0) {
+            return appendObjectIfMissing(descriptor, objectDesc);
+        }
+
+        const [first, ...rest] = path;
+        return {
+            ...descriptor,
+            arrays: descriptor.arrays.map(arr => {
+                if (arr.name !== first) {
+                    return arr;
+                }
+                return {
+                    ...arr,
+                    type: this.addObjectAtPath(arr.type, rest, objectDesc)
+                };
+            })
+        };
+    }
+
+    private primaryId(keyPath: string[], key: string): string {
+        return `${keyPathHash(keyPath)}::${key}`;
+    }
+
+    private secondaryJoinFromSecondaryRow(row: ImmutableProps): string | null {
+        const secondaryCollectionKey = this.secondary.getTypeDescriptor().collectionKey;
+        if (secondaryCollectionKey.length === 0) {
+            this.emitDiagnostic?.({
+                code: 'enrich_secondary_collection_key_missing',
+                message: 'Secondary descriptor has no collectionKey; enrichment cannot match rows.'
+            });
+            return null;
+        }
+        if (secondaryCollectionKey.length !== this.primaryKey.length) {
+            this.emitDiagnostic?.({
+                code: 'enrich_key_arity_mismatch',
+                message: 'Primary key count does not match secondary collection key count.'
+            });
+            return null;
+        }
+        const tuple = secondaryCollectionKey.map(name => row[name]);
+        return stableSerialize(tuple);
+    }
+
+    private primaryJoinFromPrimaryRow(row: ImmutableProps): string | null {
+        const secondaryCollectionKey = this.secondary.getTypeDescriptor().collectionKey;
+        if (secondaryCollectionKey.length !== this.primaryKey.length) {
+            this.emitDiagnostic?.({
+                code: 'enrich_key_arity_mismatch',
+                message: 'Primary key count does not match secondary collection key count.'
+            });
+            return null;
+        }
+        for (const property of this.primaryKey) {
+            if (!(property in row)) {
+                this.emitDiagnostic?.({
+                    code: 'enrich_invalid_primary_key_property',
+                    message: `Primary row does not contain key property "${property}".`
+                });
+                return null;
+            }
+        }
+        const tuple = this.primaryKey.map(name => row[name]);
+        return stableSerialize(tuple);
+    }
+
+    private resolveEnrichmentFromJoinHash(joinHash: string | null): ImmutableProps {
+        if (joinHash === null) {
+            return this.whenMissing;
+        }
+        const matched = this.secondaryRowByJoinKey.get(joinHash);
+        return matched?.immutableProps ?? this.whenMissing;
+    }
+
+    private resolveEnrichmentForPrimary(primaryRow: ImmutableProps): ImmutableProps {
+        const joinHash = this.primaryJoinFromPrimaryRow(primaryRow);
+        return this.resolveEnrichmentFromJoinHash(joinHash);
+    }
+
+    private handlePrimaryAdded(keyPath: string[], key: string, immutableProps: ImmutableProps): void {
+        const joinHash = this.primaryJoinFromPrimaryRow(immutableProps);
+        if (joinHash === null) {
+            return;
+        }
+        const id = this.primaryId(keyPath, key);
+        this.primaryRowsById.set(id, {
+            keyPath,
+            primaryKey: key,
+            immutableProps,
+            joinKeyHash: joinHash
+        });
+        let ids = this.primaryIdsByJoinKey.get(joinHash);
+        if (!ids) {
+            ids = new Set<string>();
+            this.primaryIdsByJoinKey.set(joinHash, ids);
+        }
+        ids.add(id);
+    }
+
+    private handlePrimaryRemoved(keyPath: string[], key: string, _immutableProps: ImmutableProps): void {
+        const id = this.primaryId(keyPath, key);
+        const existing = this.primaryRowsById.get(id);
+        if (!existing) {
+            return;
+        }
+        this.primaryRowsById.delete(id);
+        const ids = this.primaryIdsByJoinKey.get(existing.joinKeyHash);
+        if (!ids) {
+            return;
+        }
+        ids.delete(id);
+        if (ids.size === 0) {
+            this.primaryIdsByJoinKey.delete(existing.joinKeyHash);
+        }
+    }
+
+    private handleSecondaryAddedAtPath(
+        segmentPath: string[],
+        keyPath: string[],
+        key: string,
+        immutableProps: ImmutableProps
+    ): void {
+        const rootKey = this.getRootKey(segmentPath, keyPath, key);
+        if (!rootKey) {
+            return;
+        }
+        const oldRootRow = getRowByKey(this.secondaryState, rootKey);
+        this.secondaryState = addToKeyedArray(this.secondaryState, segmentPath, keyPath, key, immutableProps);
+        const newRootRow = getRowByKey(this.secondaryState, rootKey);
+        this.applySecondaryRootChange(oldRootRow, newRootRow);
+    }
+
+    private handleSecondaryRemovedAtPath(
+        segmentPath: string[],
+        keyPath: string[],
+        key: string,
+        _immutableProps: ImmutableProps
+    ): void {
+        const rootKey = this.getRootKey(segmentPath, keyPath, key);
+        if (!rootKey) {
+            return;
+        }
+        const oldRootRow = getRowByKey(this.secondaryState, rootKey);
+        this.secondaryState = removeFromKeyedArray(this.secondaryState, segmentPath, keyPath, key);
+        const newRootRow = getRowByKey(this.secondaryState, rootKey);
+        this.applySecondaryRootChange(oldRootRow, newRootRow);
+    }
+
+    private handleSecondaryModifiedAtPath(
+        segmentPath: string[],
+        keyPath: string[],
+        key: string,
+        propertyName: string,
+        newValue: unknown
+    ): void {
+        const rootKey = this.getRootKey(segmentPath, keyPath, key);
+        if (!rootKey) {
+            return;
+        }
+        const oldRootRow = getRowByKey(this.secondaryState, rootKey);
+        this.secondaryState = modifyInKeyedArray(this.secondaryState, segmentPath, keyPath, key, propertyName, newValue);
+        const newRootRow = getRowByKey(this.secondaryState, rootKey);
+        this.applySecondaryRootChange(oldRootRow, newRootRow);
+    }
+
+    private getRootKey(segmentPath: string[], keyPath: string[], key: string): string | null {
+        if (segmentPath.length === 0) {
+            return key;
+        }
+        if (keyPath.length === 0) {
+            return null;
+        }
+        return keyPath[0];
+    }
+
+    private applySecondaryRootChange(
+        oldRootRow: ImmutableProps | undefined,
+        newRootRow: ImmutableProps | undefined
+    ): void {
+        const oldJoinHash = oldRootRow ? this.secondaryJoinFromSecondaryRow(oldRootRow) : null;
+        const newJoinHash = newRootRow ? this.secondaryJoinFromSecondaryRow(newRootRow) : null;
+
+        if (oldJoinHash !== null && oldJoinHash !== newJoinHash) {
+            this.secondaryRowByJoinKey.delete(oldJoinHash);
+            this.emitModifiedForJoinKey(oldJoinHash, oldRootRow, this.whenMissing);
+        }
+
+        if (newJoinHash !== null && newRootRow) {
+            this.secondaryRowByJoinKey.set(newJoinHash, { keyPath: [], immutableProps: newRootRow });
+            if (oldJoinHash === newJoinHash) {
+                this.emitModifiedForJoinKey(newJoinHash, oldRootRow, newRootRow);
+            }
+            else {
+                this.emitModifiedForJoinKey(newJoinHash, this.whenMissing, newRootRow);
+            }
+            return;
+        }
+
+        if (oldJoinHash !== null && oldJoinHash === newJoinHash) {
+            this.secondaryRowByJoinKey.delete(oldJoinHash);
+            this.emitModifiedForJoinKey(oldJoinHash, oldRootRow, this.whenMissing);
+        }
+    }
+
+    private emitModifiedForJoinKey(
+        joinHash: string,
+        oldValue: ImmutableProps | undefined,
+        newValue: ImmutableProps | undefined
+    ): void {
+        const previous = oldValue ?? this.whenMissing;
+        const next = newValue ?? this.whenMissing;
+
+        if (valuesEqual(previous, next)) {
+            return;
+        }
+        const impactedPrimaryIds = this.primaryIdsByJoinKey.get(joinHash);
+        if (!impactedPrimaryIds || impactedPrimaryIds.size === 0) {
+            return;
+        }
+        for (const id of impactedPrimaryIds) {
+            const record = this.primaryRowsById.get(id);
+            if (!record) {
+                continue;
+            }
+            this.modifiedHandlers.forEach(handler => {
+                handler(record.keyPath, record.primaryKey, previous, next);
+            });
+        }
+    }
+}
+
+function collectAllMutableProperties(descriptor: DescriptorNode): string[] {
+    const mutableProps = new Set<string>();
+    for (const prop of descriptor.mutableProperties) {
+        mutableProps.add(prop);
+    }
+    for (const arrayDesc of descriptor.arrays) {
+        const nestedProps = collectAllMutableProperties(arrayDesc.type);
+        nestedProps.forEach(prop => mutableProps.add(prop));
+    }
+    return Array.from(mutableProps);
+}
+
+function createKeyToIndexMap<T>(state: KeyedArray<T>): Map<string, number> {
+    const keyToIndex = new Map<string, number>();
+    state.forEach((item, index) => keyToIndex.set(item.key, index));
+    return keyToIndex;
+}
+
+function addToKeyedArray<T>(
+    state: KeyedArray<T>,
+    segmentPath: string[],
+    keyPath: string[],
+    key: string,
+    immutableProps: ImmutableProps
+): KeyedArray<T> {
+    if (segmentPath.length === 0) {
+        return [...state, { key, value: immutableProps as T }];
+    }
+    const parentKey = keyPath[0];
+    const segment = segmentPath[0];
+    const keyToIndex = createKeyToIndexMap(state);
+    const existingItemIndex = keyToIndex.get(parentKey);
+    if (existingItemIndex === undefined) {
+        return state;
+    }
+    const existingItem = state[existingItemIndex];
+    const value = existingItem.value as Record<string, unknown>;
+    const existingArray = (value[segment] as KeyedArray<unknown>) || [];
+    const modifiedArray = addToKeyedArray(
+        existingArray,
+        segmentPath.slice(1),
+        keyPath.slice(1),
+        key,
+        immutableProps
+    );
+    const modifiedItem = {
+        key: parentKey,
+        value: {
+            ...value,
+            [segment]: modifiedArray
+        } as T
+    };
+    return [
+        ...state.slice(0, existingItemIndex),
+        modifiedItem,
+        ...state.slice(existingItemIndex + 1)
+    ];
+}
+
+function removeFromKeyedArray<T>(
+    state: KeyedArray<T>,
+    segmentPath: string[],
+    keyPath: string[],
+    key: string
+): KeyedArray<T> {
+    if (segmentPath.length === 0) {
+        return state.filter(item => item.key !== key);
+    }
+    const parentKey = keyPath[0];
+    const segment = segmentPath[0];
+    const keyToIndex = createKeyToIndexMap(state);
+    const existingItemIndex = keyToIndex.get(parentKey);
+    if (existingItemIndex === undefined) {
+        return state;
+    }
+    const existingItem = state[existingItemIndex];
+    const value = existingItem.value as Record<string, unknown>;
+    const existingArray = (value[segment] as KeyedArray<unknown>) || [];
+    const modifiedArray = removeFromKeyedArray(
+        existingArray,
+        segmentPath.slice(1),
+        keyPath.slice(1),
+        key
+    );
+    const modifiedItem = {
+        key: parentKey,
+        value: {
+            ...value,
+            [segment]: modifiedArray
+        } as T
+    };
+    return [
+        ...state.slice(0, existingItemIndex),
+        modifiedItem,
+        ...state.slice(existingItemIndex + 1)
+    ];
+}
+
+function modifyInKeyedArray<T>(
+    state: KeyedArray<T>,
+    segmentPath: string[],
+    keyPath: string[],
+    key: string,
+    name: string,
+    value: unknown
+): KeyedArray<T> {
+    if (segmentPath.length === 0) {
+        const keyToIndex = createKeyToIndexMap(state);
+        const existingItemIndex = keyToIndex.get(key);
+        if (existingItemIndex === undefined) {
+            return state;
+        }
+        const existingItem = state[existingItemIndex];
+        const existingValue = existingItem.value as Record<string, unknown>;
+        const modifiedItem = {
+            key,
+            value: {
+                ...existingValue,
+                [name]: value
+            } as T
+        };
+        return [
+            ...state.slice(0, existingItemIndex),
+            modifiedItem,
+            ...state.slice(existingItemIndex + 1)
+        ];
+    }
+
+    const parentKey = keyPath[0];
+    const segment = segmentPath[0];
+    const keyToIndex = createKeyToIndexMap(state);
+    const existingItemIndex = keyToIndex.get(parentKey);
+    if (existingItemIndex === undefined) {
+        return state;
+    }
+    const existingItem = state[existingItemIndex];
+    const existingValue = existingItem.value as Record<string, unknown>;
+    const existingArray = (existingValue[segment] as KeyedArray<unknown>) || [];
+    const modifiedArray = modifyInKeyedArray(
+        existingArray,
+        segmentPath.slice(1),
+        keyPath.slice(1),
+        key,
+        name,
+        value
+    );
+    const modifiedItem = {
+        key: parentKey,
+        value: {
+            ...existingValue,
+            [segment]: modifiedArray
+        } as T
+    };
+    return [
+        ...state.slice(0, existingItemIndex),
+        modifiedItem,
+        ...state.slice(existingItemIndex + 1)
+    ];
+}
+
+function getRowByKey(
+    state: KeyedArray<ImmutableProps>,
+    key: string
+): ImmutableProps | undefined {
+    return state.find(item => item.key === key)?.value;
+}

--- a/src/test/pipeline.enrich.mutable-primary-key.test.ts
+++ b/src/test/pipeline.enrich.mutable-primary-key.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Regression tests for EnrichStep when primary join keys can change after add
+ * (e.g. via defineProperty depending on mutable aggregate `total`).
+ *
+ * EnrichStep listens for `onModified` on each `primaryKey` column, moves primaries between
+ * join-key index sets, and emits `onModified` for the `as` property when enrichment changes.
+ */
+import { createPipeline } from '../index';
+import { createTestPipeline } from './helpers';
+
+interface BucketSource {
+    joinKey: string;
+    label: string;
+}
+
+interface CompositeBucketSource {
+    compositeKey: string;
+    label: string;
+}
+
+function bucketLabelFromEnrichment(bucketInfo: unknown): string | undefined {
+    const row = bucketInfo as { buckets?: Array<{ value?: { label?: string } }> } | undefined;
+    return row?.buckets?.[0]?.value?.label;
+}
+
+function regionTagFromEnrichment(regionInfo: unknown): string | undefined {
+    const row = regionInfo as { regions?: Array<{ value?: { tag?: string } }> } | undefined;
+    return row?.regions?.[0]?.value?.tag;
+}
+
+function compositeLabel(extra: unknown): string | undefined {
+    const row = extra as { rows?: Array<{ value?: { label?: string } }> } | undefined;
+    return row?.rows?.[0]?.value?.label;
+}
+
+describe('enrich — primary join key changes after add (expected failures until reindex)', () => {
+    /**
+     * Scenario 1 — “mutable FK”: join key derived from aggregate crosses a threshold;
+     * secondary has both targets. Enrichment should follow the new key.
+     */
+    it('scenario 1: after total crosses threshold, enrichment should match secondary for new join key', () => {
+        const [pipeline, getOutput] = createTestPipeline(() =>
+            createPipeline<{ orderId: string; amount: number }>()
+                .groupBy(['orderId'], 'lines')
+                .sum('items', 'amount', 'total')
+                .defineProperty('joinKey', item => (item.total > 50 ? 'high' : 'low'), ['total'])
+                .enrich(
+                    'buckets',
+                    createPipeline<BucketSource, 'buckets'>('buckets').groupBy(['joinKey'], 'buckets'),
+                    ['joinKey'],
+                    'bucketInfo'
+                )
+        );
+
+        const sources = pipeline.sources as {
+            buckets: { add: (key: string, row: BucketSource) => void };
+        };
+        sources.buckets.add('s-high', { joinKey: 'high', label: 'High tier' });
+        sources.buckets.add('s-low', { joinKey: 'low', label: 'Low tier' });
+
+        pipeline.add('l1', { orderId: 'o1', amount: 30 });
+        expect(getOutput()[0].joinKey).toBe('low');
+        expect(bucketLabelFromEnrichment(getOutput()[0].bucketInfo)).toBe('Low tier');
+
+        pipeline.add('l2', { orderId: 'o1', amount: 40 });
+
+        const row = getOutput()[0];
+        expect(row.joinKey).toBe('high');
+        expect(bucketLabelFromEnrichment(row.bucketInfo)).toBe('High tier');
+    });
+
+    /**
+     * Scenario 2 — computed defineProperty key: same mechanism, different thresholds;
+     * stresses that recompute is driven by `total` onModified, not remove/add.
+     */
+    it('scenario 2: defineProperty joinKey should drive enrichment when only total mutates', () => {
+        const [pipeline, getOutput] = createTestPipeline(() =>
+            createPipeline<{ orderId: string; amount: number }>()
+                .groupBy(['orderId'], 'lines')
+                .sum('items', 'amount', 'total')
+                .defineProperty('regionKey', item => (item.total > 40 ? 'east' : 'west'), ['total'])
+                .enrich(
+                    'regions',
+                    createPipeline<{ regionKey: string; tag: string }, 'regions'>('regions').groupBy(
+                        ['regionKey'],
+                        'regions'
+                    ),
+                    ['regionKey'],
+                    'regionInfo',
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    { regionKey: '', regions: [] } as any
+                )
+        );
+
+        const sources = pipeline.sources as {
+            regions: { add: (key: string, row: { regionKey: string; tag: string }) => void };
+        };
+        sources.regions.add('r-east', { regionKey: 'east', tag: 'EAST' });
+        sources.regions.add('r-west', { regionKey: 'west', tag: 'WEST' });
+
+        pipeline.add('a', { orderId: 'o1', amount: 20 });
+        expect(getOutput()[0].regionKey).toBe('west');
+
+        pipeline.add('b', { orderId: 'o1', amount: 25 });
+
+        const row = getOutput()[0];
+        expect(row.regionKey).toBe('east');
+        expect(regionTagFromEnrichment(row.regionInfo)).toBe('EAST');
+    });
+
+    /**
+     * Scenario 3 — secondary static: both secondary rows registered before any primary add;
+     * no further secondary mutations while the primary join key changes (different threshold than scenario 1).
+     */
+    it('scenario 3: secondary fully preloaded — no source adds during primary-only updates', () => {
+        const [pipeline, getOutput] = createTestPipeline(() =>
+            createPipeline<{ orderId: string; amount: number }>()
+                .groupBy(['orderId'], 'lines')
+                .sum('items', 'amount', 'total')
+                .defineProperty('joinKey', item => (item.total > 100 ? 'vip' : 'std'), ['total'])
+                .enrich(
+                    'buckets',
+                    createPipeline<BucketSource, 'buckets'>('buckets').groupBy(['joinKey'], 'buckets'),
+                    ['joinKey'],
+                    'bucketInfo'
+                )
+        );
+
+        const sources = pipeline.sources as {
+            buckets: { add: (key: string, row: BucketSource) => void };
+        };
+        sources.buckets.add('s-vip', { joinKey: 'vip', label: 'VIP' });
+        sources.buckets.add('s-std', { joinKey: 'std', label: 'Standard' });
+
+        pipeline.add('l1', { orderId: 'o1', amount: 60 });
+        pipeline.add('l2', { orderId: 'o1', amount: 50 });
+
+        const row = getOutput()[0];
+        expect(row.joinKey).toBe('vip');
+        expect(bucketLabelFromEnrichment(row.bucketInfo)).toBe('VIP');
+    });
+
+    /**
+     * Scenario 4 — collision: two groups share the same join key, then only one crosses the threshold.
+     */
+    it('scenario 4: only one of two primaries should move to a new join bucket', () => {
+        const [pipeline, getOutput] = createTestPipeline(() =>
+            createPipeline<{ orderId: string; amount: number }>()
+                .groupBy(['orderId'], 'lines')
+                .sum('items', 'amount', 'total')
+                .defineProperty('joinKey', item => (item.total > 50 ? 'high' : 'low'), ['total'])
+                .enrich(
+                    'buckets',
+                    createPipeline<BucketSource, 'buckets'>('buckets').groupBy(['joinKey'], 'buckets'),
+                    ['joinKey'],
+                    'bucketInfo'
+                )
+        );
+
+        const sources = pipeline.sources as {
+            buckets: { add: (key: string, row: BucketSource) => void };
+        };
+        sources.buckets.add('s-high', { joinKey: 'high', label: 'High tier' });
+        sources.buckets.add('s-low', { joinKey: 'low', label: 'Low tier' });
+
+        pipeline.add('a', { orderId: 'o1', amount: 30 });
+        pipeline.add('b', { orderId: 'o2', amount: 30 });
+        expect(getOutput()).toHaveLength(2);
+        expect(getOutput()[0].joinKey).toBe('low');
+        expect(getOutput()[1].joinKey).toBe('low');
+
+        pipeline.add('c', { orderId: 'o1', amount: 40 });
+
+        const rows = getOutput().slice().sort((x, y) => x.orderId.localeCompare(y.orderId));
+        const o1 = rows.find(r => r.orderId === 'o1')!;
+        const o2 = rows.find(r => r.orderId === 'o2')!;
+        expect(o1.joinKey).toBe('high');
+        expect(o2.joinKey).toBe('low');
+        expect(bucketLabelFromEnrichment(o1.bucketInfo)).toBe('High tier');
+        expect(bucketLabelFromEnrichment(o2.bucketInfo)).toBe('Low tier');
+    });
+
+    /**
+     * Scenario 5 — whenMissing: primary starts in a band with no secondary row, then moves to a matched band.
+     */
+    it('scenario 5: whenMissing then real match after join key changes', () => {
+        const [pipeline, getOutput] = createTestPipeline(() =>
+            createPipeline<{ orderId: string; amount: number }>()
+                .groupBy(['orderId'], 'lines')
+                .sum('items', 'amount', 'total')
+                .defineProperty('joinKey', item => (item.total > 50 ? 'high' : 'low'), ['total'])
+                .enrich(
+                    'buckets',
+                    createPipeline<BucketSource, 'buckets'>('buckets').groupBy(['joinKey'], 'buckets'),
+                    ['joinKey'],
+                    'bucketInfo',
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    { joinKey: '', buckets: [] } as any
+                )
+        );
+
+        const sources = pipeline.sources as {
+            buckets: { add: (key: string, row: BucketSource) => void };
+        };
+        sources.buckets.add('s-high', { joinKey: 'high', label: 'High tier' });
+
+        pipeline.add('l1', { orderId: 'o1', amount: 30 });
+        let row = getOutput()[0];
+        expect(row.joinKey).toBe('low');
+        expect(row.bucketInfo).toEqual({ joinKey: '', buckets: [] });
+
+        pipeline.add('l2', { orderId: 'o1', amount: 40 });
+        row = getOutput()[0];
+        expect(row.joinKey).toBe('high');
+        expect(bucketLabelFromEnrichment(row.bucketInfo)).toBe('High tier');
+    });
+
+    /**
+     * Scenario 6 — enriched secondary row’s own join key should match primary joinKey (detects stale `as`).
+     */
+    it('scenario 6: bucketInfo.joinKey should match primary joinKey after recompute', () => {
+        const [pipeline, getOutput] = createTestPipeline(() =>
+            createPipeline<{ orderId: string; amount: number }>()
+                .groupBy(['orderId'], 'lines')
+                .sum('items', 'amount', 'total')
+                .defineProperty('joinKey', item => (item.total > 50 ? 'high' : 'low'), ['total'])
+                .enrich(
+                    'buckets',
+                    createPipeline<BucketSource, 'buckets'>('buckets').groupBy(['joinKey'], 'buckets'),
+                    ['joinKey'],
+                    'bucketInfo'
+                )
+        );
+
+        const sources = pipeline.sources as {
+            buckets: { add: (key: string, row: BucketSource) => void };
+        };
+        sources.buckets.add('s-high', { joinKey: 'high', label: 'High tier' });
+        sources.buckets.add('s-low', { joinKey: 'low', label: 'Low tier' });
+
+        pipeline.add('l1', { orderId: 'o1', amount: 30 });
+        pipeline.add('l2', { orderId: 'o1', amount: 40 });
+
+        const row = getOutput()[0];
+        const info = row.bucketInfo as { joinKey?: string } | undefined;
+        expect(row.joinKey).toBe('high');
+        expect(info?.joinKey).toBe(row.joinKey);
+    });
+
+    /**
+     * Scenario 7 — composite-style join key string (multi-part semantics in one key).
+     */
+    it('scenario 7: composite join key should remap enrichment when total crosses threshold', () => {
+        const [pipeline, getOutput] = createTestPipeline(() =>
+            createPipeline<{ orderId: string; amount: number }>()
+                .groupBy(['orderId'], 'lines')
+                .sum('items', 'amount', 'total')
+                .defineProperty(
+                    'compositeKey',
+                    item => `acc-${item.total > 50 ? 'big' : 'small'}`,
+                    ['total']
+                )
+                .enrich(
+                    'rows',
+                    createPipeline<CompositeBucketSource, 'rows'>('rows').groupBy(['compositeKey'], 'rows'),
+                    ['compositeKey'],
+                    'extra'
+                )
+        );
+
+        const sources = pipeline.sources as {
+            rows: { add: (key: string, row: CompositeBucketSource) => void };
+        };
+        sources.rows.add('k1', { compositeKey: 'acc-big', label: 'Big pool' });
+        sources.rows.add('k2', { compositeKey: 'acc-small', label: 'Small pool' });
+
+        pipeline.add('l1', { orderId: 'o1', amount: 30 });
+        expect(getOutput()[0].compositeKey).toBe('acc-small');
+        expect(compositeLabel(getOutput()[0].extra)).toBe('Small pool');
+
+        pipeline.add('l2', { orderId: 'o1', amount: 40 });
+
+        const row = getOutput()[0];
+        expect(row.compositeKey).toBe('acc-big');
+        expect(compositeLabel(row.extra)).toBe('Big pool');
+    });
+});

--- a/src/test/pipeline.enrich.test.ts
+++ b/src/test/pipeline.enrich.test.ts
@@ -13,6 +13,30 @@ interface CustomerStatus {
 }
 
 describe('pipeline enrich', () => {
+    it('uses undefined for the enriched property when whenMissing is omitted', () => {
+        const [pipeline, getOutput] = createTestPipeline(() =>
+            createPipeline<Order, 'orders'>('orders')
+                .enrich(
+                    'customerStatuses',
+                    createPipeline<CustomerStatus, 'customerStatuses'>('customerStatuses')
+                        .groupBy(['customerId'], 'customerStatuses'),
+                    ['customerId'],
+                    'customerStatus'
+                )
+        );
+
+        pipeline.add('order-1', { orderId: 'order-1', customerId: 'c-1', total: 125 });
+
+        expect(getOutput()).toEqual([
+            {
+                orderId: 'order-1',
+                customerId: 'c-1',
+                total: 125,
+                customerStatus: undefined
+            }
+        ]);
+    });
+
     it('keeps primary rows and applies whenMissing until a secondary match appears', () => {
         const [pipeline, getOutput] = createTestPipeline(() =>
             createPipeline<Order, 'orders'>('orders')

--- a/src/test/pipeline.enrich.test.ts
+++ b/src/test/pipeline.enrich.test.ts
@@ -1,0 +1,192 @@
+import { createPipeline } from '../index';
+import { createTestPipeline } from './helpers';
+
+interface Order {
+    orderId: string;
+    customerId: string;
+    total: number;
+}
+
+interface CustomerStatus {
+    customerId: string;
+    status: string;
+}
+
+describe('pipeline enrich', () => {
+    it('keeps primary rows and applies whenMissing until a secondary match appears', () => {
+        const [pipeline, getOutput] = createTestPipeline(() =>
+            createPipeline<Order, 'orders'>('orders')
+                .enrich(
+                    'customerStatuses',
+                    createPipeline<CustomerStatus, 'customerStatuses'>('customerStatuses')
+                        .groupBy(['customerId'], 'customerStatuses'),
+                    ['customerId'],
+                    'customerStatus',
+                    {
+                        customerId: '',
+                        customerStatuses: []
+                    }
+                )
+        );
+
+        pipeline.add('order-1', { orderId: 'order-1', customerId: 'c-1', total: 125 });
+
+        expect(getOutput()).toEqual([
+            {
+                orderId: 'order-1',
+                customerId: 'c-1',
+                total: 125,
+                customerStatus: {
+                    customerId: '',
+                    customerStatuses: []
+                }
+            }
+        ]);
+
+        const sources = (pipeline as unknown as {
+            sources: {
+                customerStatuses: {
+                    add: (key: string, immutableProps: CustomerStatus) => void;
+                };
+            };
+        }).sources;
+
+        sources.customerStatuses.add('status-1', { customerId: 'c-1', status: 'gold' });
+
+        expect(getOutput()).toEqual([
+            {
+                orderId: 'order-1',
+                customerId: 'c-1',
+                total: 125,
+                customerStatus: {
+                    customerId: 'c-1',
+                    customerStatuses: [{ key: 'status-1', value: { status: 'gold' } }]
+                }
+            }
+        ]);
+    });
+
+    it('updates only primary rows whose join key matches changed secondary rows', () => {
+        const [pipeline, getOutput] = createTestPipeline(() =>
+            createPipeline<Order, 'orders'>('orders')
+                .enrich(
+                    'customerStatuses',
+                    createPipeline<CustomerStatus, 'customerStatuses'>('customerStatuses')
+                        .groupBy(['customerId'], 'customerStatuses'),
+                    ['customerId'],
+                    'customerStatus',
+                    {
+                        customerId: '',
+                        customerStatuses: []
+                    }
+                )
+        );
+
+        pipeline.add('order-1', { orderId: 'order-1', customerId: 'c-1', total: 50 });
+        pipeline.add('order-2', { orderId: 'order-2', customerId: 'c-2', total: 75 });
+
+        const sources = (pipeline as unknown as {
+            sources: {
+                customerStatuses: {
+                    add: (key: string, immutableProps: CustomerStatus) => void;
+                };
+            };
+        }).sources;
+
+        sources.customerStatuses.add('status-c1', { customerId: 'c-1', status: 'silver' });
+
+        expect(getOutput()).toEqual([
+            {
+                orderId: 'order-1',
+                customerId: 'c-1',
+                total: 50,
+                customerStatus: {
+                    customerId: 'c-1',
+                    customerStatuses: [{ key: 'status-c1', value: { status: 'silver' } }]
+                }
+            },
+            {
+                orderId: 'order-2',
+                customerId: 'c-2',
+                total: 75,
+                customerStatus: {
+                    customerId: '',
+                    customerStatuses: []
+                }
+            }
+        ]);
+    });
+
+    it('emits enrich_key_arity_mismatch and keeps whenMissing when key arity differs', () => {
+        const diagnostics: string[] = [];
+        let latestState: Array<{ key: string; value: {
+            orderId: string;
+            customerId: string;
+            total: number;
+            customerStatus: { customerId: string; customerStatuses: Array<{ key: string; value: { status: string } }> };
+        } }> = [];
+
+        const pipeline = createPipeline<Order, 'orders'>('orders')
+            .enrich(
+                'customerStatuses',
+                createPipeline<CustomerStatus, 'customerStatuses'>('customerStatuses')
+                    .groupBy(['customerId'], 'customerStatuses'),
+                ['customerId', 'orderId'],
+                'customerStatus',
+                {
+                    customerId: '',
+                    customerStatuses: []
+                }
+            )
+            .build(transform => {
+                latestState = transform(latestState);
+            }, {
+                onDiagnostic: diagnostic => diagnostics.push(diagnostic.code)
+            });
+
+        pipeline.add('order-1', { orderId: 'order-1', customerId: 'c-1', total: 125 });
+        pipeline.sources.customerStatuses.add('status-1', { customerId: 'c-1', status: 'gold' });
+        pipeline.flush();
+
+        expect(diagnostics).toContain('enrich_key_arity_mismatch');
+        expect(latestState).toEqual([
+            {
+                key: 'order-1',
+                value: {
+                    orderId: 'order-1',
+                    customerId: 'c-1',
+                    total: 125,
+                    customerStatus: {
+                        customerId: '',
+                        customerStatuses: []
+                    }
+                }
+            }
+        ]);
+    });
+
+    it('emits enrich_secondary_collection_key_missing when secondary has no collection key', () => {
+        const diagnostics: string[] = [];
+
+        const pipeline = createPipeline<Order, 'orders'>('orders')
+            .enrich(
+                'customerStatuses',
+                createPipeline<CustomerStatus, 'customerStatuses'>('customerStatuses'),
+                ['customerId'],
+                'customerStatus',
+                {
+                    customerId: '',
+                    status: ''
+                }
+            )
+            .build(() => undefined, {
+                onDiagnostic: diagnostic => diagnostics.push(diagnostic.code)
+            });
+
+        pipeline.add('order-1', { orderId: 'order-1', customerId: 'c-1', total: 125 });
+        pipeline.sources.customerStatuses.add('status-1', { customerId: 'c-1', status: 'gold' });
+        pipeline.flush();
+
+        expect(diagnostics).toContain('enrich_secondary_collection_key_missing');
+    });
+});

--- a/src/test/pipeline.enrich.type.test-d.ts
+++ b/src/test/pipeline.enrich.type.test-d.ts
@@ -1,0 +1,111 @@
+import { expectError, expectType } from 'tsd';
+import { createPipeline, type KeyedArray, type PipelineOutput } from '../index.js';
+
+interface Order {
+    orderId: string;
+    customerId: string;
+    regionId: string;
+    total: number;
+}
+
+interface CustomerStatus {
+    customerId: string;
+    status: string;
+}
+
+interface RegionStatus {
+    regionId: string;
+    label: string;
+}
+
+function noopSetState(): never {
+    throw new Error('not implemented');
+}
+
+{
+    const customerStatusPipeline = createPipeline<CustomerStatus, 'customerStatuses'>('customerStatuses')
+        .groupBy(['customerId'], 'customerStatuses');
+
+    const ordersPipeline = createPipeline<Order, 'orders'>('orders')
+        .enrich(
+            'customerStatuses',
+            customerStatusPipeline,
+            ['customerId'],
+            'customerStatus',
+            {
+                customerId: '',
+                customerStatuses: []
+            }
+        );
+
+    type Row = PipelineOutput<typeof ordersPipeline>;
+    expectType<{
+        orderId: string;
+        customerId: string;
+        regionId: string;
+        total: number;
+        customerStatus: PipelineOutput<typeof customerStatusPipeline>;
+    }>({} as Row);
+}
+
+{
+    const customerStatusPipeline = createPipeline<CustomerStatus, 'customerStatuses'>('customerStatuses')
+        .groupBy(['customerId'], 'customerStatuses');
+
+    expectError(
+        createPipeline<Order, 'orders'>('orders').enrich(
+            'customerStatuses',
+            customerStatusPipeline,
+            ['customerId'],
+            'customerStatus',
+            {
+                customerId: ''
+            }
+        )
+    );
+}
+
+{
+    const customerStatusPipeline = createPipeline<CustomerStatus, 'customerStatuses'>('customerStatuses')
+        .groupBy(['customerId'], 'customerStatuses');
+
+    expectError(
+        createPipeline<Order, 'orders'>('orders').enrich(
+            'customerStatuses',
+            customerStatusPipeline,
+            ['doesNotExist'],
+            'customerStatus'
+        )
+    );
+}
+
+{
+    type NestedSecondaryInput = { rows: KeyedArray<CustomerStatus> };
+    const nestedSecondary = createPipeline<NestedSecondaryInput, 'root'>('root').in('rows');
+
+    expectError(
+        createPipeline<Order, 'orders'>('orders').enrich(
+            'customerStatuses',
+            nestedSecondary,
+            ['customerId'],
+            'customerStatus'
+        )
+    );
+}
+
+{
+    const customerStatusPipeline = createPipeline<CustomerStatus, 'customerStatuses'>('customerStatuses')
+        .groupBy(['customerId'], 'customerStatuses');
+    const regionPipeline = createPipeline<RegionStatus, 'regions'>('regions')
+        .groupBy(['regionId'], 'regions');
+
+    const built = createPipeline<Order, 'orders'>('orders')
+        .enrich('customerStatuses', customerStatusPipeline, ['customerId'], 'customerStatus')
+        .enrich('regions', regionPipeline, ['regionId'], 'regionStatus')
+        .build(noopSetState);
+
+    expectType<(key: string, immutableProps: CustomerStatus) => void>(built.sources.customerStatuses.add);
+    expectType<(key: string, immutableProps: RegionStatus) => void>(built.sources.regions.add);
+    type SourceNames = keyof typeof built.sources;
+    expectType<'customerStatuses' | 'regions'>({} as SourceNames);
+}

--- a/src/test/pipeline.enrich.type.test-d.ts
+++ b/src/test/pipeline.enrich.type.test-d.ts
@@ -109,3 +109,44 @@ function noopSetState(): never {
     type SourceNames = keyof typeof built.sources;
     expectType<'customerStatuses' | 'regions'>({} as SourceNames);
 }
+
+{
+    const customerStatusPipeline = createPipeline<CustomerStatus, 'customerStatuses'>('customerStatuses')
+        .groupBy(['customerId'], 'customerStatuses');
+
+    const noDefaultOrders = createPipeline<Order, 'orders'>('orders').enrich(
+        'customerStatuses',
+        customerStatusPipeline,
+        ['customerId'],
+        'customerStatus'
+    );
+    type RowWithoutDefault = PipelineOutput<typeof noDefaultOrders>;
+    expectType<{
+        orderId: string;
+        customerId: string;
+        regionId: string;
+        total: number;
+        customerStatus: PipelineOutput<typeof customerStatusPipeline> | undefined;
+    }>({} as RowWithoutDefault);
+}
+
+{
+    const customerStatusPipeline = createPipeline<CustomerStatus, 'customerStatuses'>('customerStatuses')
+        .groupBy(['customerId'], 'customerStatuses');
+
+    const withDefaultOrders = createPipeline<Order, 'orders'>('orders').enrich(
+        'customerStatuses',
+        customerStatusPipeline,
+        ['customerId'],
+        'customerStatus',
+        { customerId: '', customerStatuses: [] }
+    );
+    type RowWithDefault = PipelineOutput<typeof withDefaultOrders>;
+    expectType<{
+        orderId: string;
+        customerId: string;
+        regionId: string;
+        total: number;
+        customerStatus: PipelineOutput<typeof customerStatusPipeline>;
+    }>({} as RowWithDefault);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- implement `PipelineBuilder.enrich(...)` as a primary-driven keyed enrichment primitive
- add `EnrichStep` runtime behavior that attaches full secondary row snapshots and emits scoped modifications when matched secondary data changes
- extend pipeline source typing and runtime input surfaces so `build()` returns typed `pipeline.sources.<sourceName>` inputs
- add TDD coverage for enrich runtime behavior, diagnostics edge cases, and compile-time type contracts
- fix lint errors for empty-object types by replacing `{}` defaults with non-widening empty-map types (`Record<never, never>`), preserving strict source-key inference

## What changed
- **Pipeline typing/runtime surface**
  - `src/pipeline.ts`
    - introduced recursive `PipelineSources<TSources>`
    - updated `PipelineInput<T, TSources>` to include `sources`
    - updated `Pipeline<TStart, TSources>` to extend typed `PipelineInput`
    - added enrich-related diagnostic codes to `PipelineRuntimeDiagnostic.code`
    - replaced `{}` generic defaults with `Record<never, never>` to satisfy lint without widening key space
- **Builder/factory integration**
  - `src/builder.ts`
    - threaded `TSources` through `PipelineBuilder` and `PipelineOutput`
    - added `enrich(...)` API with type-safe primary key and `whenMissing` contracts
    - wired secondary source inputs into returned pipeline session via `sources`
    - added deferred diagnostic bridge for enrich construction-time/runtime validation diagnostics
    - replaced `{}` generic defaults with `Record<never, never>`
  - `src/factory.ts`
    - updated `InputPipeline` to satisfy typed `sources` contract
    - replaced `{}` usages with `Record<never, never>` in empty-source positions
- **New enrichment step**
  - `src/steps/enrich.ts`
    - implemented incremental primary/secondary indexing by aligned join-key tuples
    - emits enriched add/remove at scope with fallback to `whenMissing`
    - emits `onModified(as)` only for primary rows impacted by changed secondary join keys
    - handles nested secondary state reconstruction for array/object descriptors
    - emits meaningful diagnostics for key arity mismatch, invalid primary key property, and missing secondary collection key

## Tests (TDD)
- Added runtime tests in `src/test/pipeline.enrich.test.ts` for:
  - happy-path enrichment with `whenMissing`
  - join-key-localized secondary updates
  - failure diagnostics: `enrich_key_arity_mismatch`, `enrich_secondary_collection_key_missing`
- Added type tests in `src/test/pipeline.enrich.type.test-d.ts` for:
  - enrich output typing
  - `whenMissing` full-shape typing
  - invalid key/type constraints
  - nested/scoped enrich typing
  - recursive and multi-source `pipeline.sources` typing

## Validation
- `npm run lint`
- `npm test -- --runInBand src/test/pipeline.enrich.test.ts`
- `npm run test:types -- --files "src/test/pipeline.enrich.type.test-d.ts"`
- `npm test -- --runInBand`
- `npm run test:types`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2725bd17-a572-45d8-8a0a-f3d2ef79272d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2725bd17-a572-45d8-8a0a-f3d2ef79272d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

