### PR TITLE
Implement replaceToDelta pipeline step

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -21,6 +21,7 @@ import { MinMaxAggregateStep } from './steps/min-max-aggregate.js';
 import { AverageAggregateStep } from './steps/average-aggregate.js';
 import { PickByMinMaxStep } from './steps/pick-by-min-max.js';
 import { EnrichStep } from './steps/enrich.js';
+import { ReplaceToDeltaStep } from './steps/replace-to-delta.js';
 
 // Public types
 export type KeyedArray<T> = { key: string, value: T }[];
@@ -338,6 +339,36 @@ type ArrayItemAtCurrentPath<
 > = NavigateToPath<T, Path>[ArrayName] extends KeyedArray<infer ItemType>
     ? ItemType
     : never;
+
+type ArrayPropertyNameOn<T> = {
+    [K in keyof T]-?: T[K] extends KeyedArray<unknown> ? K : never
+}[keyof T] & string;
+
+type AddNumericProperties<
+    T,
+    OutputProps extends readonly string[]
+> = Expand<T & Record<OutputProps[number], number>>;
+
+type ReplaceToDeltaAtScope<
+    TScope,
+    EntityArrayName extends string,
+    EventArrayName extends string,
+    OutputProps extends readonly string[]
+> = EntityArrayName extends keyof TScope
+    ? TScope[EntityArrayName] extends KeyedArray<infer EntityItem>
+        ? Expand<Omit<TScope, EntityArrayName> & {
+            [K in EntityArrayName]: KeyedArray<
+                EventArrayName extends keyof EntityItem
+                    ? EntityItem[EventArrayName] extends KeyedArray<infer EventItem>
+                        ? Expand<Omit<EntityItem, EventArrayName> & {
+                            [E in EventArrayName]: KeyedArray<AddNumericProperties<EventItem, OutputProps>>
+                        }>
+                        : EntityItem
+                    : EntityItem
+            >
+        }>
+        : TScope
+    : TScope;
 
 /**
  * Replaces an array property with an aggregate property at a specific level.
@@ -756,6 +787,48 @@ export class PipelineBuilder<
             outputProperty,
             propertyName,
             (left, right) => right - left
+        );
+        return new PipelineBuilder(this.input, newStep, [] as unknown as Path, this.diagnosticBridge);
+    }
+
+    replaceToDelta<
+        EntityArrayName extends ArrayPropertyNameAtCurrentPath<T, Path>,
+        EventArrayName extends ArrayPropertyNameOn<ArrayItemAtCurrentPath<T, Path, EntityArrayName>>,
+        OutputProps extends readonly string[]
+    >(
+        entityArrayName: EntityArrayName,
+        eventArrayName: EventArrayName,
+        orderBy: readonly string[],
+        properties: readonly string[],
+        outputProperties: OutputProps
+    ): PipelineBuilder<
+        Path extends []
+            ? ReplaceToDeltaAtScope<T, EntityArrayName, EventArrayName, OutputProps>
+            : Expand<
+                TransformAtPath<
+                    T,
+                    Path,
+                    ReplaceToDeltaAtScope<
+                        NavigateToPath<T, Path>,
+                        EntityArrayName,
+                        EventArrayName,
+                        OutputProps
+                    >
+                >
+            >,
+        TStart,
+        Path,
+        RootScopeName,
+        TSources
+    > {
+        const fullEntitySegmentPath = [...this.scopeSegments, entityArrayName];
+        const newStep = new ReplaceToDeltaStep(
+            this.lastStep,
+            fullEntitySegmentPath,
+            eventArrayName,
+            [...orderBy],
+            [...properties],
+            [...outputProperties]
         );
         return new PipelineBuilder(this.input, newStep, [] as unknown as Path, this.diagnosticBridge);
     }

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -344,6 +344,13 @@ type ArrayPropertyNameOn<T> = {
     [K in keyof T]-?: T[K] extends KeyedArray<unknown> ? K : never
 }[keyof T] & string;
 
+type ArrayItemAtPropertyOn<
+    T,
+    ArrayName extends ArrayPropertyNameOn<T>
+> = T[ArrayName] extends KeyedArray<infer ItemType>
+    ? ItemType
+    : never;
+
 type AddNumericProperties<
     T,
     OutputProps extends readonly string[]
@@ -794,12 +801,13 @@ export class PipelineBuilder<
     replaceToDelta<
         EntityArrayName extends ArrayPropertyNameAtCurrentPath<T, Path>,
         EventArrayName extends ArrayPropertyNameOn<ArrayItemAtCurrentPath<T, Path, EntityArrayName>>,
+        EventItem extends ArrayItemAtPropertyOn<ArrayItemAtCurrentPath<T, Path, EntityArrayName>, EventArrayName>,
         OutputProps extends readonly string[]
     >(
         entityArrayName: EntityArrayName,
         eventArrayName: EventArrayName,
-        orderBy: readonly string[],
-        properties: readonly string[],
+        orderBy: readonly (keyof EventItem & string)[],
+        properties: readonly (keyof EventItem & string)[],
         outputProperties: OutputProps
     ): PipelineBuilder<
         Path extends []

--- a/src/steps/replace-to-delta.ts
+++ b/src/steps/replace-to-delta.ts
@@ -149,6 +149,7 @@ export class ReplaceToDeltaStep implements Step {
     private readonly eventSegmentPath: string[];
     private readonly propertyToOutput: Map<string, string>;
     private readonly outputPropertiesSet: Set<string>;
+    private readonly orderBySet: Set<string>;
 
     private readonly entities: Map<string, EntityState> = new Map();
     private readonly addedHandlers: AddedHandler[] = [];
@@ -171,6 +172,7 @@ export class ReplaceToDeltaStep implements Step {
             this.propertyToOutput.set(property, this.outputProperties[index]);
         });
         this.outputPropertiesSet = new Set(this.outputProperties);
+        this.orderBySet = new Set(this.orderBy);
 
         this.input.onAdded(this.eventSegmentPath, (keyPath, key, immutableProps) => {
             this.handleEventAdded(keyPath, key, immutableProps);
@@ -178,9 +180,9 @@ export class ReplaceToDeltaStep implements Step {
         this.input.onRemoved(this.eventSegmentPath, (keyPath, key, immutableProps) => {
             this.handleEventRemoved(keyPath, key, immutableProps);
         });
-        for (const property of new Set(this.properties)) {
+        for (const property of new Set([...this.properties, ...this.orderBy])) {
             this.input.onModified(this.eventSegmentPath, property, (keyPath, key, oldValue, newValue) => {
-                this.handlePropertyModified(keyPath, key, property, oldValue, newValue);
+                this.handleTrackedPropertyModified(keyPath, key, property, oldValue, newValue);
             });
         }
     }
@@ -230,6 +232,15 @@ export class ReplaceToDeltaStep implements Step {
         }
         if (this.properties.length !== this.outputProperties.length) {
             throw new Error('ReplaceToDeltaStep requires properties and outputProperties to have equal length.');
+        }
+        const seenProperties = new Set<string>();
+        for (const property of this.properties) {
+            if (seenProperties.has(property)) {
+                throw new Error(
+                    `ReplaceToDeltaStep properties contains duplicate property "${property}".`
+                );
+            }
+            seenProperties.add(property);
         }
 
         const inputDescriptor = this.input.getTypeDescriptor();
@@ -370,7 +381,21 @@ export class ReplaceToDeltaStep implements Step {
         this.emitRemoved(parentKeyPath, eventKey, record.immutableProps, deltas);
     }
 
-    private handlePropertyModified(
+    private handleTrackedPropertyModified(
+        parentKeyPath: string[],
+        eventKey: string,
+        propertyName: string,
+        oldValue: unknown,
+        newValue: unknown
+    ): void {
+        if (this.orderBySet.has(propertyName)) {
+            this.handleOrderByPropertyModified(parentKeyPath, eventKey, propertyName, newValue);
+            return;
+        }
+        this.handleValuePropertyModified(parentKeyPath, eventKey, propertyName, oldValue, newValue);
+    }
+
+    private handleValuePropertyModified(
         parentKeyPath: string[],
         eventKey: string,
         propertyName: string,
@@ -427,6 +452,35 @@ export class ReplaceToDeltaStep implements Step {
                 this.emitModified(parentKeyPath, successorKey, outputProperty, oldSuccessorDelta, newSuccessorDelta);
             }
         }
+    }
+
+    private handleOrderByPropertyModified(
+        parentKeyPath: string[],
+        eventKey: string,
+        propertyName: string,
+        newValue: unknown
+    ): void {
+        const entity = this.entities.get(computeKeyPathHash(parentKeyPath));
+        if (!entity) {
+            return;
+        }
+        const record = entity.eventsByKey.get(eventKey);
+        if (!record) {
+            return;
+        }
+        const eventIndex = entity.sortedEventKeys.indexOf(eventKey);
+        if (eventIndex < 0) {
+            return;
+        }
+
+        const previousSnapshot = this.snapshotEntityDeltas(entity);
+
+        record.mutableValues.set(propertyName, newValue);
+        entity.sortedEventKeys.splice(eventIndex, 1);
+        this.insertEventKey(entity, eventKey);
+
+        const nextSnapshot = this.snapshotEntityDeltas(entity);
+        this.emitDeltaSnapshotChanges(parentKeyPath, previousSnapshot, nextSnapshot);
     }
 
     private emitSuccessorDeltaChanges(
@@ -495,6 +549,40 @@ export class ReplaceToDeltaStep implements Step {
         handlers.forEach(handler => {
             handler(parentKeyPath, eventKey, oldValue, newValue);
         });
+    }
+
+    private snapshotEntityDeltas(entity: EntityState): Map<string, Record<string, number>> {
+        const snapshot = new Map<string, Record<string, number>>();
+        let predecessor: EventRecord | undefined;
+        for (const key of entity.sortedEventKeys) {
+            const record = entity.eventsByKey.get(key);
+            if (!record) {
+                continue;
+            }
+            snapshot.set(key, this.computeAllDeltas(record, predecessor));
+            predecessor = record;
+        }
+        return snapshot;
+    }
+
+    private emitDeltaSnapshotChanges(
+        parentKeyPath: string[],
+        previousSnapshot: Map<string, Record<string, number>>,
+        nextSnapshot: Map<string, Record<string, number>>
+    ): void {
+        for (const [key, nextDeltas] of nextSnapshot.entries()) {
+            const previousDeltas = previousSnapshot.get(key);
+            if (!previousDeltas) {
+                continue;
+            }
+            for (const outputProperty of this.outputProperties) {
+                const oldValue = previousDeltas[outputProperty];
+                const newValue = nextDeltas[outputProperty];
+                if (!Object.is(oldValue, newValue)) {
+                    this.emitModified(parentKeyPath, key, outputProperty, oldValue, newValue);
+                }
+            }
+        }
     }
 
     private getOrCreateEntity(parentKeyPath: string[]): EntityState {

--- a/src/steps/replace-to-delta.ts
+++ b/src/steps/replace-to-delta.ts
@@ -1,0 +1,588 @@
+import type {
+    AddedHandler,
+    ArrayDescriptor,
+    DescriptorNode,
+    ImmutableProps,
+    ModifiedHandler,
+    RemovedHandler,
+    Step,
+    TypeDescriptor
+} from '../pipeline.js';
+import { pathsMatch } from '../util/path.js';
+
+interface EventRecord {
+    immutableProps: ImmutableProps;
+    mutableValues: Map<string, unknown>;
+}
+
+interface EntityState {
+    eventsByKey: Map<string, EventRecord>;
+    sortedEventKeys: string[];
+}
+
+function computeKeyPathHash(keyPath: string[]): string {
+    return keyPath.join('::');
+}
+
+function finiteNumericValue(value: unknown): number {
+    if (value === null || value === undefined) {
+        return 0;
+    }
+    const n = Number(value);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function comparePrimitiveValues(left: unknown, right: unknown): number {
+    if (typeof left === 'number' && typeof right === 'number') {
+        return left - right;
+    }
+    if (typeof left === 'string' && typeof right === 'string') {
+        if (left < right) {
+            return -1;
+        }
+        if (left > right) {
+            return 1;
+        }
+        return 0;
+    }
+    if (typeof left === 'boolean' && typeof right === 'boolean') {
+        if (left === right) {
+            return 0;
+        }
+        return left ? 1 : -1;
+    }
+    const leftAsString = String(left);
+    const rightAsString = String(right);
+    if (leftAsString < rightAsString) {
+        return -1;
+    }
+    if (leftAsString > rightAsString) {
+        return 1;
+    }
+    return 0;
+}
+
+function navigateToArrayDescriptor(
+    descriptor: DescriptorNode,
+    segmentPath: string[]
+): ArrayDescriptor | undefined {
+    if (segmentPath.length === 0) {
+        return undefined;
+    }
+
+    let current: DescriptorNode = descriptor;
+    for (let i = 0; i < segmentPath.length; i++) {
+        const segment = segmentPath[i];
+        const arrayDescriptor = current.arrays.find(array => array.name === segment);
+        if (!arrayDescriptor) {
+            return undefined;
+        }
+        if (i === segmentPath.length - 1) {
+            return arrayDescriptor;
+        }
+        current = arrayDescriptor.type;
+    }
+    return undefined;
+}
+
+function addOutputPropertiesAtPath(
+    descriptor: DescriptorNode,
+    entitySegmentPath: string[],
+    eventArrayName: string,
+    outputProperties: string[]
+): DescriptorNode {
+    if (entitySegmentPath.length === 0) {
+        return {
+            ...descriptor,
+            arrays: descriptor.arrays.map(arrayDescriptor => {
+                if (arrayDescriptor.name !== eventArrayName) {
+                    return arrayDescriptor;
+                }
+                return {
+                    ...arrayDescriptor,
+                    type: addOutputPropertiesToEventNode(arrayDescriptor.type, outputProperties)
+                };
+            })
+        };
+    }
+
+    const [head, ...tail] = entitySegmentPath;
+    return {
+        ...descriptor,
+        arrays: descriptor.arrays.map(arrayDescriptor => {
+            if (arrayDescriptor.name !== head) {
+                return arrayDescriptor;
+            }
+            return {
+                ...arrayDescriptor,
+                type: addOutputPropertiesAtPath(arrayDescriptor.type, tail, eventArrayName, outputProperties)
+            };
+        })
+    };
+}
+
+function addOutputPropertiesToEventNode(node: DescriptorNode, outputProperties: string[]): DescriptorNode {
+    const nextScalars = [...node.scalars];
+    const nextMutableProperties = [...node.mutableProperties];
+
+    for (const outputProperty of outputProperties) {
+        if (!nextScalars.some(scalar => scalar.name === outputProperty)) {
+            nextScalars.push({ name: outputProperty, type: 'number' });
+        }
+        if (!nextMutableProperties.includes(outputProperty)) {
+            nextMutableProperties.push(outputProperty);
+        }
+    }
+
+    return {
+        ...node,
+        scalars: nextScalars,
+        mutableProperties: nextMutableProperties
+    };
+}
+
+/**
+ * Converts absolute event values into per-event deltas relative to the predecessor
+ * event within each entity's sorted event list.
+ */
+export class ReplaceToDeltaStep implements Step {
+    private readonly eventSegmentPath: string[];
+    private readonly propertyToOutput: Map<string, string>;
+    private readonly outputPropertiesSet: Set<string>;
+
+    private readonly entities: Map<string, EntityState> = new Map();
+    private readonly addedHandlers: AddedHandler[] = [];
+    private readonly removedHandlers: RemovedHandler[] = [];
+    private readonly modifiedHandlersByProperty: Map<string, ModifiedHandler[]> = new Map();
+
+    constructor(
+        private readonly input: Step,
+        private readonly entitySegmentPath: string[],
+        private readonly eventArrayName: string,
+        private readonly orderBy: string[],
+        private readonly properties: string[],
+        private readonly outputProperties: string[]
+    ) {
+        this.eventSegmentPath = [...entitySegmentPath, eventArrayName];
+        this.validateConfiguration();
+
+        this.propertyToOutput = new Map();
+        this.properties.forEach((property, index) => {
+            this.propertyToOutput.set(property, this.outputProperties[index]);
+        });
+        this.outputPropertiesSet = new Set(this.outputProperties);
+
+        this.input.onAdded(this.eventSegmentPath, (keyPath, key, immutableProps) => {
+            this.handleEventAdded(keyPath, key, immutableProps);
+        });
+        this.input.onRemoved(this.eventSegmentPath, (keyPath, key, immutableProps) => {
+            this.handleEventRemoved(keyPath, key, immutableProps);
+        });
+        for (const property of new Set(this.properties)) {
+            this.input.onModified(this.eventSegmentPath, property, (keyPath, key, oldValue, newValue) => {
+                this.handlePropertyModified(keyPath, key, property, oldValue, newValue);
+            });
+        }
+    }
+
+    getTypeDescriptor(): TypeDescriptor {
+        const inputDescriptor = this.input.getTypeDescriptor();
+        return {
+            ...addOutputPropertiesAtPath(
+                inputDescriptor,
+                this.entitySegmentPath,
+                this.eventArrayName,
+                this.outputProperties
+            ),
+            rootCollectionName: inputDescriptor.rootCollectionName
+        };
+    }
+
+    onAdded(pathSegments: string[], handler: AddedHandler): void {
+        if (pathsMatch(pathSegments, this.eventSegmentPath)) {
+            this.addedHandlers.push(handler);
+            return;
+        }
+        this.input.onAdded(pathSegments, handler);
+    }
+
+    onRemoved(pathSegments: string[], handler: RemovedHandler): void {
+        if (pathsMatch(pathSegments, this.eventSegmentPath)) {
+            this.removedHandlers.push(handler);
+            return;
+        }
+        this.input.onRemoved(pathSegments, handler);
+    }
+
+    onModified(pathSegments: string[], propertyName: string, handler: ModifiedHandler): void {
+        if (pathsMatch(pathSegments, this.eventSegmentPath) && this.outputPropertiesSet.has(propertyName)) {
+            const handlers = this.modifiedHandlersByProperty.get(propertyName) ?? [];
+            handlers.push(handler);
+            this.modifiedHandlersByProperty.set(propertyName, handlers);
+            return;
+        }
+        this.input.onModified(pathSegments, propertyName, handler);
+    }
+
+    private validateConfiguration(): void {
+        if (this.orderBy.length === 0) {
+            throw new Error('ReplaceToDeltaStep requires at least one orderBy property.');
+        }
+        if (this.properties.length !== this.outputProperties.length) {
+            throw new Error('ReplaceToDeltaStep requires properties and outputProperties to have equal length.');
+        }
+
+        const inputDescriptor = this.input.getTypeDescriptor();
+        const entityArrayDescriptor = navigateToArrayDescriptor(inputDescriptor, this.entitySegmentPath);
+        if (!entityArrayDescriptor) {
+            throw new Error(
+                `ReplaceToDeltaStep could not find entity array at path [${this.entitySegmentPath.join('.')}] in descriptor.`
+            );
+        }
+        const eventArrayDescriptor = entityArrayDescriptor.type.arrays.find(array => array.name === this.eventArrayName);
+        if (!eventArrayDescriptor) {
+            throw new Error(
+                `ReplaceToDeltaStep could not find event array "${this.eventArrayName}" under entity path [${this.entitySegmentPath.join('.')}] in descriptor.`
+            );
+        }
+
+        const eventScalarNames = new Set(eventArrayDescriptor.type.scalars.map(scalar => scalar.name));
+        const hasEventScalarMetadata = eventArrayDescriptor.type.scalars.length > 0;
+        const knownEventPropertyNames = new Set<string>([...this.orderBy, ...this.properties]);
+        if (hasEventScalarMetadata) {
+            for (const orderProperty of this.orderBy) {
+                if (!eventScalarNames.has(orderProperty)) {
+                    throw new Error(
+                        `ReplaceToDeltaStep orderBy property "${orderProperty}" is not a scalar on event type "${this.eventArrayName}".`
+                    );
+                }
+            }
+            for (const property of this.properties) {
+                if (!eventScalarNames.has(property)) {
+                    throw new Error(
+                        `ReplaceToDeltaStep property "${property}" is not a scalar on event type "${this.eventArrayName}".`
+                    );
+                }
+            }
+        }
+        for (const collectionKeyPart of eventArrayDescriptor.type.collectionKey) {
+            if (!this.orderBy.includes(collectionKeyPart)) {
+                throw new Error(
+                    `ReplaceToDeltaStep orderBy must include collectionKey property "${collectionKeyPart}" for event type "${this.eventArrayName}".`
+                );
+            }
+        }
+        const seenOutputProperties = new Set<string>();
+        for (const outputProperty of this.outputProperties) {
+            if (knownEventPropertyNames.has(outputProperty)) {
+                throw new Error(
+                    `ReplaceToDeltaStep output property "${outputProperty}" collides with an existing event property.`
+                );
+            }
+            if (hasEventScalarMetadata && eventScalarNames.has(outputProperty)) {
+                throw new Error(
+                    `ReplaceToDeltaStep output property "${outputProperty}" collides with an existing scalar on event type "${this.eventArrayName}".`
+                );
+            }
+            if (seenOutputProperties.has(outputProperty)) {
+                throw new Error(
+                    `ReplaceToDeltaStep output property "${outputProperty}" is duplicated in outputProperties.`
+                );
+            }
+            seenOutputProperties.add(outputProperty);
+        }
+    }
+
+    private handleEventAdded(parentKeyPath: string[], eventKey: string, immutableProps: ImmutableProps): void {
+        const entity = this.getOrCreateEntity(parentKeyPath);
+
+        const existingRecord = entity.eventsByKey.get(eventKey);
+        if (existingRecord) {
+            this.handleEventRemoved(parentKeyPath, eventKey, existingRecord.immutableProps);
+        }
+
+        const record: EventRecord = {
+            immutableProps,
+            mutableValues: new Map()
+        };
+        entity.eventsByKey.set(eventKey, record);
+
+        const insertIndex = this.insertEventKey(entity, eventKey);
+        const predecessor = insertIndex > 0
+            ? entity.eventsByKey.get(entity.sortedEventKeys[insertIndex - 1])
+            : undefined;
+        const successorKey = insertIndex < entity.sortedEventKeys.length - 1
+            ? entity.sortedEventKeys[insertIndex + 1]
+            : undefined;
+
+        const deltas = this.computeAllDeltas(record, predecessor);
+        this.emitAdded(parentKeyPath, eventKey, immutableProps, deltas);
+
+        if (successorKey) {
+            this.emitSuccessorDeltaChanges(parentKeyPath, successorKey, predecessor, record);
+        }
+    }
+
+    private handleEventRemoved(parentKeyPath: string[], eventKey: string, immutableProps: ImmutableProps): void {
+        const entityHash = computeKeyPathHash(parentKeyPath);
+        const entity = this.entities.get(entityHash);
+        if (!entity) {
+            const fallbackRecord: EventRecord = {
+                immutableProps,
+                mutableValues: new Map()
+            };
+            this.emitRemoved(parentKeyPath, eventKey, immutableProps, this.computeAllDeltas(fallbackRecord, undefined));
+            return;
+        }
+
+        const eventIndex = entity.sortedEventKeys.indexOf(eventKey);
+        if (eventIndex < 0) {
+            const fallbackRecord: EventRecord = {
+                immutableProps,
+                mutableValues: new Map()
+            };
+            this.emitRemoved(parentKeyPath, eventKey, immutableProps, this.computeAllDeltas(fallbackRecord, undefined));
+            return;
+        }
+
+        const record = entity.eventsByKey.get(eventKey) ?? {
+            immutableProps,
+            mutableValues: new Map()
+        };
+        const predecessor = eventIndex > 0
+            ? entity.eventsByKey.get(entity.sortedEventKeys[eventIndex - 1])
+            : undefined;
+        const successorKey = eventIndex < entity.sortedEventKeys.length - 1
+            ? entity.sortedEventKeys[eventIndex + 1]
+            : undefined;
+
+        if (successorKey) {
+            this.emitSuccessorDeltaChanges(parentKeyPath, successorKey, record, predecessor);
+        }
+
+        entity.sortedEventKeys.splice(eventIndex, 1);
+        entity.eventsByKey.delete(eventKey);
+        if (entity.sortedEventKeys.length === 0) {
+            this.entities.delete(entityHash);
+        }
+
+        const deltas = this.computeAllDeltas(record, predecessor);
+        this.emitRemoved(parentKeyPath, eventKey, record.immutableProps, deltas);
+    }
+
+    private handlePropertyModified(
+        parentKeyPath: string[],
+        eventKey: string,
+        propertyName: string,
+        oldValue: unknown,
+        newValue: unknown
+    ): void {
+        const outputProperty = this.propertyToOutput.get(propertyName);
+        if (!outputProperty) {
+            return;
+        }
+
+        const entity = this.entities.get(computeKeyPathHash(parentKeyPath));
+        if (!entity) {
+            return;
+        }
+        const record = entity.eventsByKey.get(eventKey);
+        if (!record) {
+            return;
+        }
+
+        const eventIndex = entity.sortedEventKeys.indexOf(eventKey);
+        if (eventIndex < 0) {
+            return;
+        }
+
+        const predecessor = eventIndex > 0
+            ? entity.eventsByKey.get(entity.sortedEventKeys[eventIndex - 1])
+            : undefined;
+        const successorKey = eventIndex < entity.sortedEventKeys.length - 1
+            ? entity.sortedEventKeys[eventIndex + 1]
+            : undefined;
+
+        const predecessorValue = predecessor
+            ? this.getNumericPropertyValue(predecessor, propertyName)
+            : 0;
+        const oldDelta = finiteNumericValue(oldValue) - predecessorValue;
+        const newDelta = finiteNumericValue(newValue) - predecessorValue;
+
+        record.mutableValues.set(propertyName, newValue);
+
+        if (!Object.is(oldDelta, newDelta)) {
+            this.emitModified(parentKeyPath, eventKey, outputProperty, oldDelta, newDelta);
+        }
+
+        if (successorKey) {
+            const successor = entity.eventsByKey.get(successorKey);
+            if (!successor) {
+                return;
+            }
+            const successorValue = this.getNumericPropertyValue(successor, propertyName);
+            const oldSuccessorDelta = successorValue - finiteNumericValue(oldValue);
+            const newSuccessorDelta = successorValue - finiteNumericValue(newValue);
+            if (!Object.is(oldSuccessorDelta, newSuccessorDelta)) {
+                this.emitModified(parentKeyPath, successorKey, outputProperty, oldSuccessorDelta, newSuccessorDelta);
+            }
+        }
+    }
+
+    private emitSuccessorDeltaChanges(
+        parentKeyPath: string[],
+        successorKey: string,
+        oldPredecessor: EventRecord | undefined,
+        newPredecessor: EventRecord | undefined
+    ): void {
+        const entity = this.entities.get(computeKeyPathHash(parentKeyPath));
+        if (!entity) {
+            return;
+        }
+        const successorRecord = entity.eventsByKey.get(successorKey);
+        if (!successorRecord) {
+            return;
+        }
+
+        this.properties.forEach((propertyName, index) => {
+            const outputProperty = this.outputProperties[index];
+            const oldDelta = this.computeDeltaForProperty(successorRecord, oldPredecessor, propertyName);
+            const newDelta = this.computeDeltaForProperty(successorRecord, newPredecessor, propertyName);
+            if (!Object.is(oldDelta, newDelta)) {
+                this.emitModified(parentKeyPath, successorKey, outputProperty, oldDelta, newDelta);
+            }
+        });
+    }
+
+    private emitAdded(
+        parentKeyPath: string[],
+        eventKey: string,
+        immutableProps: ImmutableProps,
+        deltas: Record<string, number>
+    ): void {
+        const augmentedProps: ImmutableProps = {
+            ...immutableProps,
+            ...deltas
+        };
+        this.addedHandlers.forEach(handler => {
+            handler(parentKeyPath, eventKey, augmentedProps);
+        });
+    }
+
+    private emitRemoved(
+        parentKeyPath: string[],
+        eventKey: string,
+        immutableProps: ImmutableProps,
+        deltas: Record<string, number>
+    ): void {
+        const augmentedProps: ImmutableProps = {
+            ...immutableProps,
+            ...deltas
+        };
+        this.removedHandlers.forEach(handler => {
+            handler(parentKeyPath, eventKey, augmentedProps);
+        });
+    }
+
+    private emitModified(
+        parentKeyPath: string[],
+        eventKey: string,
+        outputProperty: string,
+        oldValue: number,
+        newValue: number
+    ): void {
+        const handlers = this.modifiedHandlersByProperty.get(outputProperty) ?? [];
+        handlers.forEach(handler => {
+            handler(parentKeyPath, eventKey, oldValue, newValue);
+        });
+    }
+
+    private getOrCreateEntity(parentKeyPath: string[]): EntityState {
+        const entityHash = computeKeyPathHash(parentKeyPath);
+        const existing = this.entities.get(entityHash);
+        if (existing) {
+            return existing;
+        }
+        const created: EntityState = {
+            eventsByKey: new Map(),
+            sortedEventKeys: []
+        };
+        this.entities.set(entityHash, created);
+        return created;
+    }
+
+    private insertEventKey(entity: EntityState, eventKey: string): number {
+        const sortedEventKeys = entity.sortedEventKeys;
+        let low = 0;
+        let high = sortedEventKeys.length;
+
+        while (low < high) {
+            const mid = Math.floor((low + high) / 2);
+            const midKey = sortedEventKeys[mid];
+            const comparison = this.compareEvents(entity, eventKey, midKey);
+            if (comparison < 0) {
+                high = mid;
+            } else {
+                low = mid + 1;
+            }
+        }
+
+        sortedEventKeys.splice(low, 0, eventKey);
+        return low;
+    }
+
+    private compareEvents(entity: EntityState, leftKey: string, rightKey: string): number {
+        const leftRecord = entity.eventsByKey.get(leftKey);
+        const rightRecord = entity.eventsByKey.get(rightKey);
+        if (!leftRecord || !rightRecord) {
+            return leftKey.localeCompare(rightKey);
+        }
+
+        for (const orderProperty of this.orderBy) {
+            const leftValue = this.getComparableOrderValue(leftRecord, orderProperty);
+            const rightValue = this.getComparableOrderValue(rightRecord, orderProperty);
+            const comparison = comparePrimitiveValues(leftValue, rightValue);
+            if (comparison !== 0) {
+                return comparison;
+            }
+        }
+
+        return leftKey.localeCompare(rightKey);
+    }
+
+    private getComparableOrderValue(record: EventRecord, propertyName: string): unknown {
+        if (record.mutableValues.has(propertyName)) {
+            return record.mutableValues.get(propertyName);
+        }
+        return record.immutableProps[propertyName];
+    }
+
+    private getNumericPropertyValue(record: EventRecord, propertyName: string): number {
+        if (record.mutableValues.has(propertyName)) {
+            return finiteNumericValue(record.mutableValues.get(propertyName));
+        }
+        return finiteNumericValue(record.immutableProps[propertyName]);
+    }
+
+    private computeDeltaForProperty(
+        current: EventRecord,
+        predecessor: EventRecord | undefined,
+        propertyName: string
+    ): number {
+        const currentValue = this.getNumericPropertyValue(current, propertyName);
+        const predecessorValue = predecessor ? this.getNumericPropertyValue(predecessor, propertyName) : 0;
+        return currentValue - predecessorValue;
+    }
+
+    private computeAllDeltas(
+        current: EventRecord,
+        predecessor: EventRecord | undefined
+    ): Record<string, number> {
+        const deltas: Record<string, number> = {};
+        this.properties.forEach((propertyName, index) => {
+            const outputProperty = this.outputProperties[index];
+            deltas[outputProperty] = this.computeDeltaForProperty(current, predecessor, propertyName);
+        });
+        return deltas;
+    }
+}

--- a/src/test/pipeline.replace-to-delta.test.ts
+++ b/src/test/pipeline.replace-to-delta.test.ts
@@ -1,0 +1,453 @@
+// @ts-nocheck
+import { createPipeline, type DescriptorNode, type TypeDescriptor } from '../index';
+import { createTestPipeline } from './helpers';
+import { ReplaceToDeltaStep } from '../steps/replace-to-delta';
+import type { ImmutableProps, ModifiedHandler, Step } from '../pipeline';
+
+type AllocationRow = {
+    effectiveClass: string;
+    attendeeId: string;
+    createdAt: string;
+    eventId: string;
+    amount: number;
+    bonus: number;
+};
+
+type DeltaEvent = {
+    createdAt: string;
+    eventId: string;
+    amount: number;
+    bonus: number;
+    deltaAmount: number;
+    deltaBonus: number;
+};
+
+function buildReplaceToDeltaPipeline() {
+    return createPipeline<AllocationRow>()
+        .groupBy(['effectiveClass'], 'attendees')
+        .in('items').groupBy(['attendeeId'], 'attendees')
+        .replaceToDelta(
+            'attendees',
+            'items',
+            ['createdAt', 'eventId'],
+            ['amount', 'bonus'],
+            ['deltaAmount', 'deltaBonus']
+        );
+}
+
+function sortEvents(events: DeltaEvent[]): DeltaEvent[] {
+    return [...events].sort((left, right) => {
+        if (left.createdAt < right.createdAt) {
+            return -1;
+        }
+        if (left.createdAt > right.createdAt) {
+            return 1;
+        }
+        if (left.eventId < right.eventId) {
+            return -1;
+        }
+        if (left.eventId > right.eventId) {
+            return 1;
+        }
+        return 0;
+    });
+}
+
+function getAttendeeEvents(
+    output: Array<{
+        effectiveClass: string;
+        attendees: Array<{
+            attendeeId: string;
+            items: DeltaEvent[];
+        }>;
+    }>,
+    effectiveClass: string,
+    attendeeId: string
+): DeltaEvent[] {
+    const classRow = output.find(row => row.effectiveClass === effectiveClass);
+    expect(classRow).toBeDefined();
+    const attendeeRow = classRow?.attendees.find(row => row.attendeeId === attendeeId);
+    expect(attendeeRow).toBeDefined();
+    return sortEvents(attendeeRow?.items ?? []);
+}
+
+function normalizeOutput(
+    output: Array<{
+        effectiveClass: string;
+        attendees: Array<{
+            attendeeId: string;
+            items: DeltaEvent[];
+        }>;
+    }>
+) {
+    return output
+        .map(classRow => ({
+            ...classRow,
+            attendees: classRow.attendees
+                .map(attendee => ({
+                    ...attendee,
+                    items: sortEvents(attendee.items)
+                }))
+                .sort((left, right) => left.attendeeId.localeCompare(right.attendeeId))
+        }))
+        .sort((left, right) => left.effectiveClass.localeCompare(right.effectiveClass));
+}
+
+type AddedHandler = (keyPath: string[], key: string, immutableProps: ImmutableProps) => void;
+type RemovedHandler = (keyPath: string[], key: string, immutableProps: ImmutableProps) => void;
+
+class FakeStep implements Step {
+    private readonly addedHandlers = new Map<string, AddedHandler[]>();
+    private readonly removedHandlers = new Map<string, RemovedHandler[]>();
+    private readonly modifiedHandlers = new Map<string, ModifiedHandler[]>();
+
+    constructor(private readonly descriptor: TypeDescriptor) {}
+
+    getTypeDescriptor(): TypeDescriptor {
+        return this.descriptor;
+    }
+
+    onAdded(pathSegments: string[], handler: AddedHandler): void {
+        const key = JSON.stringify(pathSegments);
+        const handlers = this.addedHandlers.get(key) ?? [];
+        handlers.push(handler);
+        this.addedHandlers.set(key, handlers);
+    }
+
+    onRemoved(pathSegments: string[], handler: RemovedHandler): void {
+        const key = JSON.stringify(pathSegments);
+        const handlers = this.removedHandlers.get(key) ?? [];
+        handlers.push(handler);
+        this.removedHandlers.set(key, handlers);
+    }
+
+    onModified(pathSegments: string[], propertyName: string, handler: ModifiedHandler): void {
+        const key = `${JSON.stringify(pathSegments)}::${propertyName}`;
+        const handlers = this.modifiedHandlers.get(key) ?? [];
+        handlers.push(handler);
+        this.modifiedHandlers.set(key, handlers);
+    }
+
+    emitAdded(pathSegments: string[], keyPath: string[], key: string, immutableProps: ImmutableProps): void {
+        const handlers = this.addedHandlers.get(JSON.stringify(pathSegments)) ?? [];
+        handlers.forEach(handler => handler(keyPath, key, immutableProps));
+    }
+
+    emitRemoved(pathSegments: string[], keyPath: string[], key: string, immutableProps: ImmutableProps): void {
+        const handlers = this.removedHandlers.get(JSON.stringify(pathSegments)) ?? [];
+        handlers.forEach(handler => handler(keyPath, key, immutableProps));
+    }
+
+    emitModified(
+        pathSegments: string[],
+        propertyName: string,
+        keyPath: string[],
+        key: string,
+        oldValue: unknown,
+        newValue: unknown
+    ): void {
+        const handlers = this.modifiedHandlers.get(`${JSON.stringify(pathSegments)}::${propertyName}`) ?? [];
+        handlers.forEach(handler => handler(keyPath, key, oldValue, newValue));
+    }
+}
+
+function fakeDescriptorForReplaceToDelta(eventCollectionKey: string[]): TypeDescriptor {
+    const eventNode: DescriptorNode = {
+        arrays: [],
+        collectionKey: eventCollectionKey,
+        scalars: [
+            { name: 'time', type: 'number' },
+            { name: 'id', type: 'string' },
+            { name: 'amount', type: 'number' }
+        ],
+        objects: [],
+        mutableProperties: ['amount']
+    };
+    return {
+        rootCollectionName: 'root',
+        collectionKey: [],
+        scalars: [],
+        objects: [],
+        mutableProperties: [],
+        arrays: [
+            {
+                name: 'entities',
+                type: {
+                    arrays: [
+                        {
+                            name: 'events',
+                            type: eventNode
+                        }
+                    ],
+                    collectionKey: ['entityId'],
+                    scalars: [{ name: 'entityId', type: 'string' }],
+                    objects: [],
+                    mutableProperties: []
+                }
+            }
+        ]
+    };
+}
+
+describe('pipeline replaceToDelta', () => {
+    it('should compute first-event baseline and predecessor deltas while preserving originals', () => {
+        const [pipeline, getOutput] = createTestPipeline(() => buildReplaceToDeltaPipeline());
+
+        pipeline.add('e1', {
+            effectiveClass: 'C1',
+            attendeeId: 'A1',
+            createdAt: '2026-03-10T00:00:00.000Z',
+            eventId: 'E1',
+            amount: 10,
+            bonus: 2
+        });
+        pipeline.add('e2', {
+            effectiveClass: 'C1',
+            attendeeId: 'A1',
+            createdAt: '2026-03-11T00:00:00.000Z',
+            eventId: 'E2',
+            amount: 15,
+            bonus: 3
+        });
+
+        const events = getAttendeeEvents(getOutput(), 'C1', 'A1');
+        expect(events).toEqual([
+            {
+                createdAt: '2026-03-10T00:00:00.000Z',
+                eventId: 'E1',
+                amount: 10,
+                bonus: 2,
+                deltaAmount: 10,
+                deltaBonus: 2
+            },
+            {
+                createdAt: '2026-03-11T00:00:00.000Z',
+                eventId: 'E2',
+                amount: 15,
+                bonus: 3,
+                deltaAmount: 5,
+                deltaBonus: 1
+            }
+        ]);
+    });
+
+    it('should recompute successor delta when inserting an event between two existing events', () => {
+        const [pipeline, getOutput] = createTestPipeline(() => buildReplaceToDeltaPipeline());
+
+        pipeline.add('e1', {
+            effectiveClass: 'C1',
+            attendeeId: 'A1',
+            createdAt: '2026-03-10T00:00:00.000Z',
+            eventId: 'E1',
+            amount: 10,
+            bonus: 1
+        });
+        pipeline.add('e3', {
+            effectiveClass: 'C1',
+            attendeeId: 'A1',
+            createdAt: '2026-03-12T00:00:00.000Z',
+            eventId: 'E3',
+            amount: 25,
+            bonus: 6
+        });
+
+        let events = getAttendeeEvents(getOutput(), 'C1', 'A1');
+        expect(events[1].deltaAmount).toBe(15);
+        expect(events[1].deltaBonus).toBe(5);
+
+        pipeline.add('e2', {
+            effectiveClass: 'C1',
+            attendeeId: 'A1',
+            createdAt: '2026-03-11T00:00:00.000Z',
+            eventId: 'E2',
+            amount: 18,
+            bonus: 4
+        });
+
+        events = getAttendeeEvents(getOutput(), 'C1', 'A1');
+        expect(events).toEqual([
+            {
+                createdAt: '2026-03-10T00:00:00.000Z',
+                eventId: 'E1',
+                amount: 10,
+                bonus: 1,
+                deltaAmount: 10,
+                deltaBonus: 1
+            },
+            {
+                createdAt: '2026-03-11T00:00:00.000Z',
+                eventId: 'E2',
+                amount: 18,
+                bonus: 4,
+                deltaAmount: 8,
+                deltaBonus: 3
+            },
+            {
+                createdAt: '2026-03-12T00:00:00.000Z',
+                eventId: 'E3',
+                amount: 25,
+                bonus: 6,
+                deltaAmount: 7,
+                deltaBonus: 2
+            }
+        ]);
+    });
+
+    it('should converge to identical deltas regardless of add ordering', () => {
+        const [pipelineA, getOutputA] = createTestPipeline(() => buildReplaceToDeltaPipeline());
+        const [pipelineB, getOutputB] = createTestPipeline(() => buildReplaceToDeltaPipeline());
+
+        const rows: AllocationRow[] = [
+            {
+                effectiveClass: 'C1',
+                attendeeId: 'A1',
+                createdAt: '2026-03-10T00:00:00.000Z',
+                eventId: 'E1',
+                amount: 10,
+                bonus: 1
+            },
+            {
+                effectiveClass: 'C1',
+                attendeeId: 'A1',
+                createdAt: '2026-03-11T00:00:00.000Z',
+                eventId: 'E2',
+                amount: 18,
+                bonus: 4
+            },
+            {
+                effectiveClass: 'C1',
+                attendeeId: 'A1',
+                createdAt: '2026-03-12T00:00:00.000Z',
+                eventId: 'E3',
+                amount: 25,
+                bonus: 6
+            }
+        ];
+
+        pipelineA.add('a2', rows[1]);
+        pipelineA.add('a1', rows[0]);
+        pipelineA.add('a3', rows[2]);
+
+        pipelineB.add('b3', rows[2]);
+        pipelineB.add('b2', rows[1]);
+        pipelineB.add('b1', rows[0]);
+
+        expect(normalizeOutput(getOutputA())).toEqual(normalizeOutput(getOutputB()));
+    });
+
+    it('should recompute successor delta after middle-event removal to match no-middle baseline', () => {
+        const [withMiddle, getWithMiddle] = createTestPipeline(() => buildReplaceToDeltaPipeline());
+        const [withoutMiddle, getWithoutMiddle] = createTestPipeline(() => buildReplaceToDeltaPipeline());
+
+        const t1 = {
+            effectiveClass: 'C1',
+            attendeeId: 'A1',
+            createdAt: '2026-03-10T00:00:00.000Z',
+            eventId: 'E1',
+            amount: 10,
+            bonus: 1
+        };
+        const t2 = {
+            effectiveClass: 'C1',
+            attendeeId: 'A1',
+            createdAt: '2026-03-11T00:00:00.000Z',
+            eventId: 'E2',
+            amount: 18,
+            bonus: 4
+        };
+        const t3 = {
+            effectiveClass: 'C1',
+            attendeeId: 'A1',
+            createdAt: '2026-03-12T00:00:00.000Z',
+            eventId: 'E3',
+            amount: 25,
+            bonus: 6
+        };
+
+        withMiddle.add('e1', t1);
+        withMiddle.add('e2', t2);
+        withMiddle.add('e3', t3);
+        withMiddle.remove('e2', t2);
+
+        withoutMiddle.add('e1', t1);
+        withoutMiddle.add('e3', t3);
+
+        expect(normalizeOutput(getWithMiddle())).toEqual(normalizeOutput(getWithoutMiddle()));
+    });
+
+    it('should reject mismatched properties/outputProperties lengths', () => {
+        expect(() => {
+            createPipeline<AllocationRow>()
+                .groupBy(['effectiveClass'], 'attendees')
+                .in('items').groupBy(['attendeeId'], 'attendees')
+                .replaceToDelta(
+                    'attendees',
+                    'items',
+                    ['createdAt', 'eventId'],
+                    ['amount'],
+                    ['deltaAmount', 'deltaBonus']
+                );
+        }).toThrow();
+    });
+
+    it('should reject output property collisions with existing event scalars', () => {
+        expect(() => {
+            createPipeline<AllocationRow>()
+                .groupBy(['effectiveClass'], 'attendees')
+                .in('items').groupBy(['attendeeId'], 'attendees')
+                .replaceToDelta(
+                    'attendees',
+                    'items',
+                    ['createdAt', 'eventId'],
+                    ['amount'],
+                    ['amount']
+                );
+        }).toThrow();
+    });
+});
+
+describe('ReplaceToDeltaStep internals', () => {
+    it('should update both the modified event delta and its successor delta', () => {
+        const fakeInput = new FakeStep(fakeDescriptorForReplaceToDelta(['id']));
+        const step = new ReplaceToDeltaStep(
+            fakeInput,
+            ['entities'],
+            'events',
+            ['time', 'id'],
+            ['amount'],
+            ['delta']
+        );
+
+        const modifiedEvents: Array<{ key: string; oldValue: unknown; newValue: unknown }> = [];
+        step.onModified(['entities', 'events'], 'delta', (keyPath, key, oldValue, newValue) => {
+            expect(keyPath).toEqual(['entity-1']);
+            modifiedEvents.push({ key, oldValue, newValue });
+        });
+
+        fakeInput.emitAdded(['entities'], [], 'entity-1', { entityId: 'E1' });
+        fakeInput.emitAdded(['entities', 'events'], ['entity-1'], 'event-1', { time: 1, id: 't1', amount: 10 });
+        fakeInput.emitAdded(['entities', 'events'], ['entity-1'], 'event-2', { time: 2, id: 't2', amount: 15 });
+
+        fakeInput.emitModified(['entities', 'events'], 'amount', ['entity-1'], 'event-1', 10, 12);
+
+        expect(modifiedEvents).toEqual([
+            { key: 'event-1', oldValue: 10, newValue: 12 },
+            { key: 'event-2', oldValue: 5, newValue: 3 }
+        ]);
+    });
+
+    it('should reject orderBy when it does not cover event collectionKey', () => {
+        const fakeInput = new FakeStep(fakeDescriptorForReplaceToDelta(['id']));
+
+        expect(() => {
+            new ReplaceToDeltaStep(
+                fakeInput,
+                ['entities'],
+                'events',
+                ['time'],
+                ['amount'],
+                ['delta']
+            );
+        }).toThrow();
+    });
+});

--- a/src/test/pipeline.replace-to-delta.test.ts
+++ b/src/test/pipeline.replace-to-delta.test.ts
@@ -404,6 +404,21 @@ describe('pipeline replaceToDelta', () => {
                 );
         }).toThrow();
     });
+
+    it('should reject duplicate properties with a meaningful error', () => {
+        expect(() => {
+            createPipeline<AllocationRow>()
+                .groupBy(['effectiveClass'], 'attendees')
+                .in('items').groupBy(['attendeeId'], 'attendees')
+                .replaceToDelta(
+                    'attendees',
+                    'items',
+                    ['createdAt', 'eventId'],
+                    ['amount', 'amount'],
+                    ['deltaAmountA', 'deltaAmountB']
+                );
+        }).toThrow('duplicate');
+    });
 });
 
 describe('ReplaceToDeltaStep internals', () => {
@@ -449,5 +464,35 @@ describe('ReplaceToDeltaStep internals', () => {
                 ['delta']
             );
         }).toThrow();
+    });
+
+    it('should recompute deltas when a mutable orderBy field changes', () => {
+        const fakeInput = new FakeStep(fakeDescriptorForReplaceToDelta(['id']));
+        const step = new ReplaceToDeltaStep(
+            fakeInput,
+            ['entities'],
+            'events',
+            ['time', 'id'],
+            ['amount'],
+            ['delta']
+        );
+
+        const modifiedEvents: Array<{ key: string; oldValue: unknown; newValue: unknown }> = [];
+        step.onModified(['entities', 'events'], 'delta', (_keyPath, key, oldValue, newValue) => {
+            modifiedEvents.push({ key, oldValue, newValue });
+        });
+
+        fakeInput.emitAdded(['entities'], [], 'entity-1', { entityId: 'E1' });
+        fakeInput.emitAdded(['entities', 'events'], ['entity-1'], 'event-1', { time: 1, id: 't1', amount: 10 });
+        fakeInput.emitAdded(['entities', 'events'], ['entity-1'], 'event-2', { time: 2, id: 't2', amount: 15 });
+
+        // Move event-1 after event-2 by changing mutable orderBy field.
+        // Expected:
+        // - event-2 becomes baseline delta: 15 (from previous 5)
+        // - event-1 becomes successor delta: -5 (from previous 10)
+        fakeInput.emitModified(['entities', 'events'], 'time', ['entity-1'], 'event-1', 1, 3);
+
+        expect(modifiedEvents).toContainEqual({ key: 'event-2', oldValue: 5, newValue: 15 });
+        expect(modifiedEvents).toContainEqual({ key: 'event-1', oldValue: 10, newValue: -5 });
     });
 });

--- a/src/test/pipeline.replace-to-delta.type.test-d.ts
+++ b/src/test/pipeline.replace-to-delta.type.test-d.ts
@@ -1,0 +1,49 @@
+import { expectError } from 'tsd';
+import { createPipeline, type KeyedArray } from '../index.js';
+
+type TimelineInput = {
+    entities: KeyedArray<{
+        entityId: string;
+        events: KeyedArray<{
+            time: number;
+            id: string;
+            amount: number;
+            bonus: number;
+        }>;
+    }>;
+};
+
+{
+    createPipeline<TimelineInput>().replaceToDelta(
+        'entities',
+        'events',
+        ['time', 'id'],
+        ['amount', 'bonus'],
+        ['deltaAmount', 'deltaBonus'] as const
+    );
+}
+
+// Expected behavior: orderBy/properties should be constrained to event keys.
+{
+    expectError(
+        createPipeline<TimelineInput>().replaceToDelta(
+            'entities',
+            'events',
+            ['missingOrderByField'],
+            ['amount'],
+            ['deltaAmount'] as const
+        )
+    );
+}
+
+{
+    expectError(
+        createPipeline<TimelineInput>().replaceToDelta(
+            'entities',
+            'events',
+            ['time', 'id'],
+            ['missingValueField'],
+            ['deltaAmount'] as const
+        )
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `ReplaceToDeltaStep` to convert absolute event values to predecessor-based deltas within each entity
- add `PipelineBuilder.replaceToDelta(...)` API with output type transformation for nested event arrays
- implement configuration validation for:
  - `properties` and `outputProperties` length mismatch
  - duplicate entries in `properties` (now rejected with meaningful error)
  - `orderBy` covering event `collectionKey`
  - output property collisions against existing event/event-derived property names
- support mutable `orderBy` fields by re-sorting entity event lists on `onModified` and emitting delta modifications for affected events
- tighten builder typing so `orderBy` and `properties` are constrained to keys of the selected event item type

## Tests
- `src/test/pipeline.replace-to-delta.test.ts`
  - baseline and predecessor deltas
  - insertion/successor recompute
  - commutativity across orderings
  - middle-event removal reversion
  - duplicate `properties` rejection with meaningful error
  - mutable `orderBy` reordering behavior
- `src/test/pipeline.replace-to-delta.type.test-d.ts`
  - compile-time key safety for `orderBy` and `properties`
- existing validation/internals tests retained

## Verification
- `npm test -- pipeline.replace-to-delta.test.ts`
- `npm run test:types`
- `npm test`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2540f66a-1dbc-40c5-9b55-31d83fd16d85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2540f66a-1dbc-40c5-9b55-31d83fd16d85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

