### PR TITLE
Implement cumulativeSum pipeline step with descriptor-consistent validation

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -21,6 +21,7 @@ import { MinMaxAggregateStep } from './steps/min-max-aggregate.js';
 import { AverageAggregateStep } from './steps/average-aggregate.js';
 import { PickByMinMaxStep } from './steps/pick-by-min-max.js';
 import { EnrichStep } from './steps/enrich.js';
+import { CumulativeSumStep } from './steps/cumulative-sum.js';
 
 // Public types
 export type KeyedArray<T> = { key: string, value: T }[];
@@ -89,6 +90,53 @@ function finiteNumericContribution(value: unknown): number {
     }
     const n = Number(value);
     return Number.isFinite(n) ? n : 0;
+}
+
+function getArrayItemDescriptorAtPath(descriptor: TypeDescriptor, segmentPath: string[]): DescriptorNode | undefined {
+    let current: DescriptorNode = descriptor;
+    for (const segment of segmentPath) {
+        const nextArray = current.arrays.find(array => array.name === segment);
+        if (!nextArray) {
+            return undefined;
+        }
+        current = nextArray.type;
+    }
+    return current;
+}
+
+function assertCumulativeSumConfiguration(
+    descriptor: TypeDescriptor,
+    segmentPath: string[],
+    orderBy: readonly string[],
+    properties: readonly string[]
+): void {
+    const itemDescriptor = getArrayItemDescriptorAtPath(descriptor, segmentPath);
+    if (!itemDescriptor) {
+        throw new Error(`cumulativeSum validation error: array path "${segmentPath.join('.')}" not found in current scope`);
+    }
+    if (orderBy.length === 0) {
+        throw new Error('cumulativeSum validation error: orderBy must include at least one scalar property');
+    }
+    if (properties.length === 0) {
+        throw new Error('cumulativeSum validation error: properties must include at least one mutable scalar property');
+    }
+
+    const scalarNames = new Set(itemDescriptor.scalars.map(scalar => scalar.name));
+    orderBy.forEach(propertyName => {
+        if (!scalarNames.has(propertyName)) {
+            throw new Error(`cumulativeSum validation error: orderBy property "${propertyName}" is not a scalar on the target array item type`);
+        }
+    });
+
+    const mutableProperties = new Set(descriptor.mutableProperties);
+    properties.forEach(propertyName => {
+        if (!scalarNames.has(propertyName)) {
+            throw new Error(`cumulativeSum validation error: property "${propertyName}" is not a scalar on the target array item type`);
+        }
+        if (!mutableProperties.has(propertyName)) {
+            throw new Error(`cumulativeSum validation error: property "${propertyName}" must be mutable`);
+        }
+    });
 }
 
 type PendingOperation =
@@ -601,6 +649,28 @@ export class PipelineBuilder<
             propertyToAggregate
         );
         return new PipelineBuilder(this.input, newStep, [] as unknown as Path, this.diagnosticBridge);
+    }
+
+    cumulativeSum<
+        ArrayName extends ArrayPropertyNameAtCurrentPath<T, Path>,
+        TOrderBy extends keyof ArrayItemAtCurrentPath<T, Path, ArrayName> & string,
+        TProperty extends keyof ArrayItemAtCurrentPath<T, Path, ArrayName> & string
+    >(
+        arrayName: ArrayName,
+        orderBy: readonly TOrderBy[],
+        properties: readonly TProperty[]
+    ): PipelineBuilder<T, TStart, Path, RootScopeName, TSources> {
+        const fullSegmentPath = [...this.scopeSegments, arrayName];
+        const inputDescriptor = this.lastStep.getTypeDescriptor();
+        assertCumulativeSumConfiguration(inputDescriptor, fullSegmentPath, orderBy, properties);
+
+        const newStep = new CumulativeSumStep(
+            this.lastStep,
+            fullSegmentPath,
+            [...orderBy],
+            [...properties]
+        );
+        return new PipelineBuilder(this.input, newStep, this.scopeSegments, this.diagnosticBridge);
     }
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ export { CommutativeAggregateStep } from './steps/commutative-aggregate.js';
 export { MinMaxAggregateStep } from './steps/min-max-aggregate.js';
 export { AverageAggregateStep } from './steps/average-aggregate.js';
 export { PickByMinMaxStep } from './steps/pick-by-min-max.js';
+export { CumulativeSumStep } from './steps/cumulative-sum.js';
 
 // Filter step
 export { FilterStep } from './steps/filter.js';

--- a/src/steps/cumulative-sum.ts
+++ b/src/steps/cumulative-sum.ts
@@ -1,0 +1,470 @@
+import type {
+    AddedHandler,
+    ImmutableProps,
+    ModifiedHandler,
+    RemovedHandler,
+    Step,
+    TypeDescriptor
+} from '../pipeline.js';
+import { pathsMatch } from '../util/path.js';
+
+type NormalizedOrderValue = number | string | undefined;
+
+interface ItemState {
+    key: string;
+    currentProps: ImmutableProps;
+    orderValues: NormalizedOrderValue[];
+    inputValues: Record<string, number>;
+    cumulativeValues: Record<string, number>;
+}
+
+interface ParentState {
+    readonly itemsByKey: Map<string, ItemState>;
+    readonly orderedKeys: string[];
+}
+
+function computeKeyPathHash(keyPath: string[]): string {
+    return keyPath.join('::');
+}
+
+function toFiniteNumber(value: unknown): number {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function normalizeOrderValue(value: unknown): NormalizedOrderValue {
+    if (value === null || value === undefined) {
+        return undefined;
+    }
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : undefined;
+    }
+    if (typeof value === 'string') {
+        return value;
+    }
+    if (typeof value === 'boolean') {
+        return value ? 1 : 0;
+    }
+    if (value instanceof Date) {
+        return Number.isFinite(value.getTime()) ? value.getTime() : undefined;
+    }
+    try {
+        return JSON.stringify(value);
+    }
+    catch {
+        return undefined;
+    }
+}
+
+function compareNormalizedOrderValues(
+    left: NormalizedOrderValue,
+    right: NormalizedOrderValue
+): number {
+    if (left === right) {
+        return 0;
+    }
+    if (left === undefined) {
+        return -1;
+    }
+    if (right === undefined) {
+        return 1;
+    }
+    if (typeof left === 'number' && typeof right === 'number') {
+        return left - right;
+    }
+    const leftAsString = String(left);
+    const rightAsString = String(right);
+    if (leftAsString < rightAsString) {
+        return -1;
+    }
+    if (leftAsString > rightAsString) {
+        return 1;
+    }
+    return 0;
+}
+
+export class CumulativeSumStep<
+    _TInput,
+    TPath extends string[],
+    TProperties extends readonly string[]
+> implements Step {
+    private readonly parentStates: Map<string, ParentState> = new Map();
+    private readonly addedHandlers: AddedHandler[] = [];
+    private readonly removedHandlers: RemovedHandler[] = [];
+    private readonly modifiedHandlers: Map<string, ModifiedHandler[]> = new Map();
+    private readonly cumulativePropertySet: Set<string>;
+    private readonly orderByPropertySet: Set<string>;
+
+    constructor(
+        private input: Step,
+        private segmentPath: TPath,
+        private orderBy: readonly string[],
+        private properties: TProperties
+    ) {
+        this.cumulativePropertySet = new Set(this.properties);
+        this.orderByPropertySet = new Set(this.orderBy);
+
+        this.input.onAdded(this.segmentPath, (keyPath, itemKey, immutableProps) => {
+            this.handleItemAdded(keyPath, itemKey, immutableProps);
+        });
+
+        this.input.onRemoved(this.segmentPath, (keyPath, itemKey, immutableProps) => {
+            this.handleItemRemoved(keyPath, itemKey, immutableProps);
+        });
+
+        const inputDescriptor = this.input.getTypeDescriptor();
+        const listenedProperties = new Set<string>([
+            ...this.properties,
+            ...this.orderBy,
+            ...inputDescriptor.mutableProperties
+        ]);
+
+        listenedProperties.forEach(propertyName => {
+            this.input.onModified(this.segmentPath, propertyName, (keyPath, itemKey, oldValue, newValue) => {
+                this.handleItemModified(keyPath, itemKey, propertyName, oldValue, newValue);
+            });
+        });
+    }
+
+    getTypeDescriptor(): TypeDescriptor {
+        return this.input.getTypeDescriptor();
+    }
+
+    onAdded(pathSegments: string[], handler: AddedHandler): void {
+        if (pathsMatch(pathSegments, this.segmentPath)) {
+            this.addedHandlers.push(handler);
+            return;
+        }
+        this.input.onAdded(pathSegments, handler);
+    }
+
+    onRemoved(pathSegments: string[], handler: RemovedHandler): void {
+        if (pathsMatch(pathSegments, this.segmentPath)) {
+            this.removedHandlers.push(handler);
+            return;
+        }
+        this.input.onRemoved(pathSegments, handler);
+    }
+
+    onModified(pathSegments: string[], propertyName: string, handler: ModifiedHandler): void {
+        if (pathsMatch(pathSegments, this.segmentPath) && this.cumulativePropertySet.has(propertyName)) {
+            const handlers = this.modifiedHandlers.get(propertyName) ?? [];
+            handlers.push(handler);
+            this.modifiedHandlers.set(propertyName, handlers);
+            return;
+        }
+        this.input.onModified(pathSegments, propertyName, handler);
+    }
+
+    private handleItemAdded(parentKeyPath: string[], itemKey: string, immutableProps: ImmutableProps): void {
+        const parentState = this.getOrCreateParentState(parentKeyPath);
+        if (parentState.itemsByKey.has(itemKey)) {
+            this.handleItemRemoved(parentKeyPath, itemKey, immutableProps);
+        }
+
+        const itemState: ItemState = {
+            key: itemKey,
+            currentProps: { ...immutableProps },
+            orderValues: this.computeOrderValues(immutableProps),
+            inputValues: this.computeInputValues(immutableProps),
+            cumulativeValues: this.createZeroedValueRecord()
+        };
+
+        const insertionIndex = this.findInsertionIndex(parentState, itemState);
+        const predecessor = insertionIndex > 0
+            ? parentState.itemsByKey.get(parentState.orderedKeys[insertionIndex - 1])
+            : undefined;
+
+        this.properties.forEach(propertyName => {
+            const predecessorCumulative = predecessor ? predecessor.cumulativeValues[propertyName] : 0;
+            itemState.cumulativeValues[propertyName] = predecessorCumulative + itemState.inputValues[propertyName];
+        });
+
+        parentState.itemsByKey.set(itemKey, itemState);
+        parentState.orderedKeys.splice(insertionIndex, 0, itemKey);
+
+        const emittedProps = this.composeOutputProps(itemState);
+        this.addedHandlers.forEach(handler => {
+            handler(parentKeyPath, itemKey, emittedProps);
+        });
+
+        this.properties.forEach(propertyName => {
+            const delta = itemState.inputValues[propertyName];
+            this.applyDeltaToSuffix(parentState, parentKeyPath, insertionIndex + 1, propertyName, delta);
+        });
+    }
+
+    private handleItemRemoved(parentKeyPath: string[], itemKey: string, _immutableProps: ImmutableProps): void {
+        const parentState = this.getParentState(parentKeyPath);
+        if (!parentState) {
+            return;
+        }
+
+        const itemState = parentState.itemsByKey.get(itemKey);
+        if (!itemState) {
+            return;
+        }
+
+        const index = parentState.orderedKeys.indexOf(itemKey);
+        if (index === -1) {
+            return;
+        }
+
+        this.properties.forEach(propertyName => {
+            const delta = -itemState.inputValues[propertyName];
+            this.applyDeltaToSuffix(parentState, parentKeyPath, index + 1, propertyName, delta);
+        });
+
+        const emittedProps = this.composeOutputProps(itemState);
+        this.removedHandlers.forEach(handler => {
+            handler(parentKeyPath, itemKey, emittedProps);
+        });
+
+        parentState.itemsByKey.delete(itemKey);
+        parentState.orderedKeys.splice(index, 1);
+
+        if (parentState.orderedKeys.length === 0) {
+            this.parentStates.delete(computeKeyPathHash(parentKeyPath));
+        }
+    }
+
+    private handleItemModified(
+        parentKeyPath: string[],
+        itemKey: string,
+        propertyName: string,
+        _oldValue: unknown,
+        newValue: unknown
+    ): void {
+        const parentState = this.getParentState(parentKeyPath);
+        if (!parentState) {
+            return;
+        }
+
+        const itemState = parentState.itemsByKey.get(itemKey);
+        if (!itemState) {
+            return;
+        }
+
+        itemState.currentProps[propertyName] = newValue;
+
+        if (this.orderByPropertySet.has(propertyName)) {
+            const nextOrderValues = this.computeOrderValues(itemState.currentProps);
+            const orderChanged = !this.areOrderTuplesEqual(itemState.orderValues, nextOrderValues);
+            if (orderChanged) {
+                this.handleOrderByPropertyChange(parentState, parentKeyPath, itemState, propertyName, newValue, nextOrderValues);
+                return;
+            }
+            itemState.orderValues = nextOrderValues;
+        }
+
+        if (this.cumulativePropertySet.has(propertyName)) {
+            this.handleCumulativePropertyChange(parentState, parentKeyPath, itemState, propertyName, newValue);
+        }
+    }
+
+    private handleCumulativePropertyChange(
+        parentState: ParentState,
+        parentKeyPath: string[],
+        itemState: ItemState,
+        propertyName: string,
+        newValue: unknown
+    ): void {
+        const oldInputValue = itemState.inputValues[propertyName];
+        const newInputValue = toFiniteNumber(newValue);
+        const delta = newInputValue - oldInputValue;
+        itemState.inputValues[propertyName] = newInputValue;
+
+        if (Object.is(delta, 0)) {
+            return;
+        }
+
+        const index = parentState.orderedKeys.indexOf(itemState.key);
+        if (index === -1) {
+            return;
+        }
+
+        this.applyDeltaToSuffix(parentState, parentKeyPath, index, propertyName, delta);
+    }
+
+    private handleOrderByPropertyChange(
+        parentState: ParentState,
+        parentKeyPath: string[],
+        itemState: ItemState,
+        changedProperty: string,
+        newValue: unknown,
+        nextOrderValues: NormalizedOrderValue[]
+    ): void {
+        const oldIndex = parentState.orderedKeys.indexOf(itemState.key);
+        if (oldIndex === -1) {
+            return;
+        }
+
+        const oldInputValues = { ...itemState.inputValues };
+        const oldCumulativeValues = { ...itemState.cumulativeValues };
+
+        if (this.cumulativePropertySet.has(changedProperty)) {
+            itemState.inputValues[changedProperty] = toFiniteNumber(newValue);
+        }
+
+        parentState.orderedKeys.splice(oldIndex, 1);
+
+        this.properties.forEach(propertyName => {
+            this.applyDeltaToSuffix(parentState, parentKeyPath, oldIndex, propertyName, -oldInputValues[propertyName]);
+        });
+
+        itemState.orderValues = nextOrderValues;
+
+        const newIndex = this.findInsertionIndex(parentState, itemState);
+        parentState.orderedKeys.splice(newIndex, 0, itemState.key);
+
+        const predecessor = newIndex > 0
+            ? parentState.itemsByKey.get(parentState.orderedKeys[newIndex - 1])
+            : undefined;
+
+        this.properties.forEach(propertyName => {
+            const predecessorCumulative = predecessor ? predecessor.cumulativeValues[propertyName] : 0;
+            const newCumulativeValue = predecessorCumulative + itemState.inputValues[propertyName];
+            itemState.cumulativeValues[propertyName] = newCumulativeValue;
+            this.emitModified(parentKeyPath, itemState.key, propertyName, oldCumulativeValues[propertyName], newCumulativeValue);
+        });
+
+        this.properties.forEach(propertyName => {
+            this.applyDeltaToSuffix(parentState, parentKeyPath, newIndex + 1, propertyName, itemState.inputValues[propertyName]);
+        });
+    }
+
+    private applyDeltaToSuffix(
+        parentState: ParentState,
+        parentKeyPath: string[],
+        startIndexInclusive: number,
+        propertyName: string,
+        delta: number
+    ): void {
+        if (Object.is(delta, 0)) {
+            return;
+        }
+
+        for (let index = startIndexInclusive; index < parentState.orderedKeys.length; index += 1) {
+            const key = parentState.orderedKeys[index];
+            const itemState = parentState.itemsByKey.get(key);
+            if (!itemState) {
+                continue;
+            }
+            const oldValue = itemState.cumulativeValues[propertyName];
+            const newValue = oldValue + delta;
+            itemState.cumulativeValues[propertyName] = newValue;
+            this.emitModified(parentKeyPath, itemState.key, propertyName, oldValue, newValue);
+        }
+    }
+
+    private emitModified(
+        keyPath: string[],
+        key: string,
+        propertyName: string,
+        oldValue: unknown,
+        newValue: unknown
+    ): void {
+        if (Object.is(oldValue, newValue)) {
+            return;
+        }
+        const handlers = this.modifiedHandlers.get(propertyName) ?? [];
+        handlers.forEach(handler => {
+            handler(keyPath, key, oldValue, newValue);
+        });
+    }
+
+    private getParentState(parentKeyPath: string[]): ParentState | undefined {
+        return this.parentStates.get(computeKeyPathHash(parentKeyPath));
+    }
+
+    private getOrCreateParentState(parentKeyPath: string[]): ParentState {
+        const parentKeyHash = computeKeyPathHash(parentKeyPath);
+        const existing = this.parentStates.get(parentKeyHash);
+        if (existing) {
+            return existing;
+        }
+        const created: ParentState = {
+            itemsByKey: new Map(),
+            orderedKeys: []
+        };
+        this.parentStates.set(parentKeyHash, created);
+        return created;
+    }
+
+    private createZeroedValueRecord(): Record<string, number> {
+        const zeroed: Record<string, number> = {};
+        this.properties.forEach(propertyName => {
+            zeroed[propertyName] = 0;
+        });
+        return zeroed;
+    }
+
+    private computeInputValues(props: ImmutableProps): Record<string, number> {
+        const values: Record<string, number> = {};
+        this.properties.forEach(propertyName => {
+            values[propertyName] = toFiniteNumber(props[propertyName]);
+        });
+        return values;
+    }
+
+    private computeOrderValues(props: ImmutableProps): NormalizedOrderValue[] {
+        return this.orderBy.map(propertyName => normalizeOrderValue(props[propertyName]));
+    }
+
+    private composeOutputProps(itemState: ItemState): ImmutableProps {
+        return {
+            ...itemState.currentProps,
+            ...itemState.cumulativeValues
+        };
+    }
+
+    private findInsertionIndex(parentState: ParentState, candidate: ItemState): number {
+        let low = 0;
+        let high = parentState.orderedKeys.length;
+
+        while (low < high) {
+            const mid = Math.floor((low + high) / 2);
+            const midItem = parentState.itemsByKey.get(parentState.orderedKeys[mid]);
+            if (!midItem) {
+                low = mid + 1;
+                continue;
+            }
+            const comparison = this.compareItems(candidate, midItem);
+            if (comparison < 0) {
+                high = mid;
+            } else {
+                low = mid + 1;
+            }
+        }
+
+        return low;
+    }
+
+    private compareItems(left: ItemState, right: ItemState): number {
+        for (let index = 0; index < this.orderBy.length; index += 1) {
+            const orderComparison = compareNormalizedOrderValues(left.orderValues[index], right.orderValues[index]);
+            if (orderComparison !== 0) {
+                return orderComparison;
+            }
+        }
+        if (left.key < right.key) {
+            return -1;
+        }
+        if (left.key > right.key) {
+            return 1;
+        }
+        return 0;
+    }
+
+    private areOrderTuplesEqual(left: NormalizedOrderValue[], right: NormalizedOrderValue[]): boolean {
+        if (left.length !== right.length) {
+            return false;
+        }
+        for (let index = 0; index < left.length; index += 1) {
+            if (!Object.is(left[index], right[index])) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/steps/define-property.ts
+++ b/src/steps/define-property.ts
@@ -1,4 +1,4 @@
-import type { ImmutableProps, ModifiedHandler, Step } from '../pipeline.js';
+import type { DescriptorNode, ImmutableProps, ModifiedHandler, Step } from '../pipeline.js';
 import { type TypeDescriptor } from '../pipeline.js';
 import { pathsMatch } from '../util/path.js';
 
@@ -38,17 +38,72 @@ export class DefinePropertyStep<T, K extends string, U> implements Step {
     
     getTypeDescriptor(): TypeDescriptor {
         const inputDescriptor = this.input.getTypeDescriptor();
+        const withScalar = this.appendDefinedScalarAtScope(inputDescriptor);
+
         // If this property depends on mutable properties, mark it as mutable too
         if (this.mutableProperties.length > 0) {
-            const existingMutableProps = inputDescriptor.mutableProperties;
+            const existingMutableProps = withScalar.mutableProperties;
             if (!existingMutableProps.includes(this.propertyName)) {
                 return {
-                    ...inputDescriptor,
+                    ...withScalar,
                     mutableProperties: [...existingMutableProps, this.propertyName]
                 };
             }
         }
-        return inputDescriptor;
+        return withScalar;
+    }
+
+    private appendDefinedScalarAtScope(inputDescriptor: TypeDescriptor): TypeDescriptor {
+        if (this.scopeSegments.length === 0) {
+            if (inputDescriptor.scalars.some(scalar => scalar.name === this.propertyName)) {
+                return inputDescriptor;
+            }
+            return {
+                ...inputDescriptor,
+                scalars: [
+                    ...inputDescriptor.scalars,
+                    { name: this.propertyName, type: 'unknown' as const }
+                ]
+            };
+        }
+
+        const appendScalarRecursively = (
+            descriptor: DescriptorNode,
+            remainingSegments: string[]
+        ): DescriptorNode => {
+            if (remainingSegments.length === 0) {
+                if (descriptor.scalars.some(scalar => scalar.name === this.propertyName)) {
+                    return descriptor;
+                }
+                return {
+                    ...descriptor,
+                    scalars: [
+                        ...descriptor.scalars,
+                        { name: this.propertyName, type: 'unknown' as const }
+                    ]
+                };
+            }
+
+            const [segment, ...tail] = remainingSegments;
+            return {
+                ...descriptor,
+                arrays: descriptor.arrays.map(arrayDesc => {
+                    if (arrayDesc.name !== segment) {
+                        return arrayDesc;
+                    }
+                    return {
+                        ...arrayDesc,
+                        type: appendScalarRecursively(arrayDesc.type, tail)
+                    };
+                })
+            };
+        };
+
+        const transformed = appendScalarRecursively(inputDescriptor, this.scopeSegments);
+        return {
+            ...transformed,
+            rootCollectionName: inputDescriptor.rootCollectionName
+        };
     }
     
     private composeItem(immutableProps: ImmutableProps, mutableValues: Map<string, unknown>): T {

--- a/src/test/pipeline.cumulative-sum.test.ts
+++ b/src/test/pipeline.cumulative-sum.test.ts
@@ -1,0 +1,307 @@
+// @ts-nocheck
+import { createPipeline } from '../index';
+import type { AddedHandler, ImmutableProps, ModifiedHandler, RemovedHandler, Step, TypeDescriptor } from '../pipeline';
+import { CumulativeSumStep } from '../steps/cumulative-sum';
+import { createTestPipeline } from './helpers';
+
+type ModifiedEvent = {
+    keyPath: string[];
+    key: string;
+    oldValue: unknown;
+    newValue: unknown;
+};
+
+class FakeInputStep implements Step {
+    private readonly addedHandlers: Map<string, AddedHandler[]> = new Map();
+    private readonly removedHandlers: Map<string, RemovedHandler[]> = new Map();
+    private readonly modifiedHandlers: Map<string, ModifiedHandler[]> = new Map();
+
+    constructor(private descriptor: TypeDescriptor) {
+    }
+
+    getTypeDescriptor(): TypeDescriptor {
+        return this.descriptor;
+    }
+
+    onAdded(pathSegments: string[], handler: AddedHandler): void {
+        const pathKey = JSON.stringify(pathSegments);
+        const handlers = this.addedHandlers.get(pathKey) ?? [];
+        handlers.push(handler);
+        this.addedHandlers.set(pathKey, handlers);
+    }
+
+    onRemoved(pathSegments: string[], handler: RemovedHandler): void {
+        const pathKey = JSON.stringify(pathSegments);
+        const handlers = this.removedHandlers.get(pathKey) ?? [];
+        handlers.push(handler);
+        this.removedHandlers.set(pathKey, handlers);
+    }
+
+    onModified(pathSegments: string[], propertyName: string, handler: ModifiedHandler): void {
+        const registrationKey = `${JSON.stringify(pathSegments)}::${propertyName}`;
+        const handlers = this.modifiedHandlers.get(registrationKey) ?? [];
+        handlers.push(handler);
+        this.modifiedHandlers.set(registrationKey, handlers);
+    }
+
+    emitAdded(pathSegments: string[], keyPath: string[], key: string, immutableProps: ImmutableProps): void {
+        const pathKey = JSON.stringify(pathSegments);
+        (this.addedHandlers.get(pathKey) ?? []).forEach(handler => handler(keyPath, key, immutableProps));
+    }
+
+    emitRemoved(pathSegments: string[], keyPath: string[], key: string, immutableProps: ImmutableProps): void {
+        const pathKey = JSON.stringify(pathSegments);
+        (this.removedHandlers.get(pathKey) ?? []).forEach(handler => handler(keyPath, key, immutableProps));
+    }
+
+    emitModified(
+        pathSegments: string[],
+        propertyName: string,
+        keyPath: string[],
+        key: string,
+        oldValue: unknown,
+        newValue: unknown
+    ): void {
+        const registrationKey = `${JSON.stringify(pathSegments)}::${propertyName}`;
+        (this.modifiedHandlers.get(registrationKey) ?? []).forEach(handler => handler(keyPath, key, oldValue, newValue));
+    }
+}
+
+function getSeriesPoints(output: Array<{ series: string; items: Array<{ time: number; change: number; change2: number }> }>, series: string) {
+    return output.find(row => row.series === series)?.items ?? [];
+}
+
+function normalizePoints(points: Array<{ time: number; change: number; change2?: number; note?: string }>) {
+    return [...points]
+        .sort((left, right) => left.time - right.time)
+        .map(point => ({ time: point.time, change: point.change, change2: point.change2, note: point.note }));
+}
+
+describe('cumulativeSum (builder)', () => {
+    function createCumulativePipeline() {
+        return createPipeline<{
+            series: string;
+            time: number;
+            change: number;
+            change2: number;
+            note: string;
+        }, 'items'>('items', [
+            { name: 'series', type: 'string' },
+            { name: 'time', type: 'number' },
+            { name: 'change', type: 'number' },
+            { name: 'change2', type: 'number' },
+            { name: 'note', type: 'string' }
+        ])
+            .groupBy(['series'], 'seriesGroups')
+            // Mark cumulative inputs as mutable to satisfy AC12 and support onModified propagation.
+            .in('items').defineProperty('change', point => point.change, ['change'])
+            .in('items').defineProperty('change2', point => point.change2, ['change2'])
+            .cumulativeSum('items', ['time'], ['change', 'change2']);
+    }
+
+    it('should produce cumulative values for a single item', () => {
+        const [pipeline, getOutput] = createTestPipeline(createCumulativePipeline);
+
+        pipeline.add('e1', { series: 'A', time: 1, change: 10, change2: 4, note: 'first' });
+
+        const output = getOutput();
+        const points = normalizePoints(getSeriesPoints(output, 'A'));
+        expect(points).toEqual([
+            { time: 1, change: 10, change2: 4, note: 'first' }
+        ]);
+    });
+
+    it('should compute prefix sums across multiple sorted items', () => {
+        const [pipeline, getOutput] = createTestPipeline(createCumulativePipeline);
+
+        pipeline.add('e1', { series: 'A', time: 1, change: 10, change2: 2, note: 'one' });
+        pipeline.add('e2', { series: 'A', time: 2, change: 5, change2: 3, note: 'two' });
+        pipeline.add('e3', { series: 'A', time: 3, change: 7, change2: 4, note: 'three' });
+
+        const points = normalizePoints(getSeriesPoints(getOutput(), 'A'));
+        expect(points).toEqual([
+            { time: 1, change: 10, change2: 2, note: 'one' },
+            { time: 2, change: 15, change2: 5, note: 'two' },
+            { time: 3, change: 22, change2: 9, note: 'three' }
+        ]);
+    });
+
+    it('should update successors when an item is inserted in the middle and when removed', () => {
+        const [pipeline, getOutput] = createTestPipeline(createCumulativePipeline);
+
+        const t1 = { series: 'A', time: 1, change: 10, change2: 1, note: 't1' };
+        const t3 = { series: 'A', time: 3, change: 5, change2: 2, note: 't3' };
+        const t2 = { series: 'A', time: 2, change: 7, change2: 4, note: 't2' };
+
+        pipeline.add('t1', t1);
+        pipeline.add('t3', t3);
+        expect(normalizePoints(getSeriesPoints(getOutput(), 'A'))).toEqual([
+            { time: 1, change: 10, change2: 1, note: 't1' },
+            { time: 3, change: 15, change2: 3, note: 't3' }
+        ]);
+
+        pipeline.add('t2', t2);
+        expect(normalizePoints(getSeriesPoints(getOutput(), 'A'))).toEqual([
+            { time: 1, change: 10, change2: 1, note: 't1' },
+            { time: 2, change: 17, change2: 5, note: 't2' },
+            { time: 3, change: 22, change2: 7, note: 't3' }
+        ]);
+
+        const beforeRemove = normalizePoints(getSeriesPoints(getOutput(), 'A'));
+        pipeline.remove('t2', t2);
+        const afterRemove = normalizePoints(getSeriesPoints(getOutput(), 'A'));
+
+        expect(afterRemove).toEqual([
+            { time: 1, change: 10, change2: 1, note: 't1' },
+            { time: 3, change: 15, change2: 3, note: 't3' }
+        ]);
+
+        pipeline.add('t2', t2);
+        pipeline.remove('t2', t2);
+        expect(normalizePoints(getSeriesPoints(getOutput(), 'A'))).toEqual(afterRemove);
+        expect(beforeRemove).not.toEqual(afterRemove);
+    });
+
+    it('should be commutative across insertion orders', () => {
+        const [pipelineA, getOutputA] = createTestPipeline(createCumulativePipeline);
+        const [pipelineB, getOutputB] = createTestPipeline(createCumulativePipeline);
+
+        const events = [
+            { key: 'e1', value: { series: 'A', time: 1, change: 10, change2: 2, note: 'one' } },
+            { key: 'e2', value: { series: 'A', time: 2, change: 5, change2: 3, note: 'two' } },
+            { key: 'e3', value: { series: 'A', time: 3, change: 7, change2: 4, note: 'three' } }
+        ];
+
+        events.forEach(event => pipelineA.add(event.key, event.value));
+        [...events].reverse().forEach(event => pipelineB.add(event.key, event.value));
+
+        expect(normalizePoints(getSeriesPoints(getOutputA(), 'A'))).toEqual(
+            normalizePoints(getSeriesPoints(getOutputB(), 'A'))
+        );
+    });
+
+    it('should produce no output for an empty collection', () => {
+        const [_, getOutput] = createTestPipeline(createCumulativePipeline);
+        expect(getOutput()).toEqual([]);
+    });
+
+    it('should reject non-mutable cumulative properties', () => {
+        expect(() => createPipeline<{ series: string; time: number; change: number }, 'items'>('items', [
+            { name: 'series', type: 'string' },
+            { name: 'time', type: 'number' },
+            { name: 'change', type: 'number' }
+        ])
+            .groupBy(['series'], 'seriesGroups')
+            .cumulativeSum('items', ['time'], ['change'])
+        ).toThrow('mutable');
+    });
+
+    it('should reject missing orderBy properties', () => {
+        expect(() => createPipeline<{ series: string; time: number; change: number }, 'items'>('items', [
+            { name: 'series', type: 'string' },
+            { name: 'time', type: 'number' },
+            { name: 'change', type: 'number' }
+        ])
+            .groupBy(['series'], 'seriesGroups')
+            .in('items').defineProperty('change', point => point.change, ['change'])
+            .cumulativeSum('items', ['missing'] as string[], ['change'])
+        ).toThrow('orderBy');
+    });
+
+    it('should reject missing arrays in current scope', () => {
+        expect(() => createPipeline<{ series: string; time: number; change: number }, 'items'>('items', [
+            { name: 'series', type: 'string' },
+            { name: 'time', type: 'number' },
+            { name: 'change', type: 'number' }
+        ])
+            .groupBy(['series'], 'seriesGroups')
+            .in('items').defineProperty('change', point => point.change, ['change'])
+            .cumulativeSum('missing' as string, ['time'], ['change'])
+        ).toThrow('array');
+    });
+});
+
+describe('CumulativeSumStep (incremental behavior)', () => {
+    function createStepHarness() {
+        const fakeInput = new FakeInputStep({
+            rootCollectionName: 'groups',
+            arrays: [
+                {
+                    name: 'items',
+                    type: {
+                        arrays: [],
+                        collectionKey: [],
+                        scalars: [
+                            { name: 'order', type: 'number' },
+                            { name: 'value', type: 'number' },
+                            { name: 'label', type: 'string' }
+                        ],
+                        objects: [],
+                        mutableProperties: ['order', 'value', 'label']
+                    }
+                }
+            ],
+            collectionKey: [],
+            scalars: [],
+            objects: [],
+            mutableProperties: []
+        });
+
+        const step = new CumulativeSumStep(
+            fakeInput,
+            ['items'],
+            ['order'],
+            ['value']
+        );
+
+        const modified: ModifiedEvent[] = [];
+        step.onModified(['items'], 'value', (keyPath, key, oldValue, newValue) => {
+            modified.push({ keyPath, key, oldValue, newValue });
+        });
+
+        return { fakeInput, step, modified };
+    }
+
+    it('should propagate cumulative value modifications through suffix on input value change', () => {
+        const { fakeInput, modified } = createStepHarness();
+
+        fakeInput.emitAdded(['items'], [], 'i1', { order: 1, value: 10, label: 'A' });
+        fakeInput.emitAdded(['items'], [], 'i2', { order: 2, value: 5, label: 'B' });
+        modified.length = 0;
+
+        fakeInput.emitModified(['items'], 'value', [], 'i1', 10, 13);
+
+        expect(modified).toEqual([
+            { keyPath: [], key: 'i1', oldValue: 10, newValue: 13 },
+            { keyPath: [], key: 'i2', oldValue: 15, newValue: 18 }
+        ]);
+    });
+
+    it('should emit no cumulative modifications for zero-delta value changes', () => {
+        const { fakeInput, modified } = createStepHarness();
+
+        fakeInput.emitAdded(['items'], [], 'i1', { order: 1, value: 10, label: 'A' });
+        fakeInput.emitAdded(['items'], [], 'i2', { order: 2, value: 5, label: 'B' });
+        modified.length = 0;
+
+        fakeInput.emitModified(['items'], 'value', [], 'i1', 10, 10);
+
+        expect(modified).toEqual([]);
+    });
+
+    it('should forward non-cumulated property modifications unchanged', () => {
+        const { fakeInput, step } = createStepHarness();
+
+        const forwarded: ModifiedEvent[] = [];
+        step.onModified(['items'], 'label', (keyPath, key, oldValue, newValue) => {
+            forwarded.push({ keyPath, key, oldValue, newValue });
+        });
+
+        fakeInput.emitAdded(['items'], [], 'i1', { order: 1, value: 10, label: 'A' });
+        fakeInput.emitModified(['items'], 'label', [], 'i1', 'A', 'B');
+
+        expect(forwarded).toEqual([
+            { keyPath: [], key: 'i1', oldValue: 'A', newValue: 'B' }
+        ]);
+    });
+});

--- a/src/test/pipeline.cumulative-sum.test.ts
+++ b/src/test/pipeline.cumulative-sum.test.ts
@@ -219,6 +219,22 @@ describe('cumulativeSum (builder)', () => {
             .cumulativeSum('missing' as string, ['time'], ['change'])
         ).toThrow('array');
     });
+
+    it('should allow cumulativeSum over mutable properties introduced by defineProperty', () => {
+        expect(() => createPipeline<{
+            series: string;
+            time: number;
+            change: number;
+        }, 'items'>('items', [
+            { name: 'series', type: 'string' },
+            { name: 'time', type: 'number' },
+            { name: 'change', type: 'number' }
+        ])
+            .groupBy(['series'], 'seriesGroups')
+            .in('items').defineProperty('derivedChange', point => point.change, ['change'])
+            .cumulativeSum('items', ['time'], ['derivedChange'])
+        ).not.toThrow();
+    });
 });
 
 describe('CumulativeSumStep (incremental behavior)', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `CumulativeSumStep` to transform configured numeric properties into prefix sums over a sorted array segment.
- Add `PipelineBuilder.cumulativeSum(arrayName, orderBy, properties)` with runtime validation for:
  - target array existence in current scope,
  - non-empty `orderBy` and `properties`,
  - `orderBy` scalar existence,
  - cumulative property scalar existence + mutability.
- Export `CumulativeSumStep` from `src/index.ts` for advanced usage.
- Add TDD coverage in `src/test/pipeline.cumulative-sum.test.ts` for:
  - single/multi-item prefix behavior,
  - insertion/removal suffix updates and add-remove inversion,
  - commutativity across insertion orders,
  - empty output behavior,
  - validation failures,
  - step-level incremental `onModified` behavior including zero-delta suppression and forwarding non-cumulated property changes,
  - defineProperty-introduced mutable property compatibility.
- Fix `DefinePropertyStep.getTypeDescriptor()` to append the defined property as a scalar at the correct scope path (type `unknown`) so descriptor metadata stays aligned with builder/runtime validation.

## Verification
- `npm test -- pipeline.cumulative-sum.test.ts -t "introduced by defineProperty"`
- `npm test -- pipeline.cumulative-sum.test.ts`
- `npm run typecheck`
- `npm test`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a10d541-59dc-4150-9ace-529d3f4947ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a10d541-59dc-4150-9ace-529d3f4947ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

