### PR TITLE
Implement flatten pipeline step

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -23,6 +23,7 @@ import { PickByMinMaxStep } from './steps/pick-by-min-max.js';
 import { EnrichStep } from './steps/enrich.js';
 import { CumulativeSumStep } from './steps/cumulative-sum.js';
 import { ReplaceToDeltaStep } from './steps/replace-to-delta.js';
+import { FlattenStep } from './steps/flatten.js';
 
 // Public types
 export type KeyedArray<T> = { key: string, value: T }[];
@@ -425,6 +426,36 @@ type ReplaceToDeltaAtScope<
         : TScope
     : TScope;
 
+type ArrayPropertyName<T> = {
+    [K in keyof T]-?: T[K] extends KeyedArray<unknown> ? K : never
+}[keyof T] & string;
+
+type FlattenMergedItem<ParentItem, ChildArrayName extends string> =
+    ChildArrayName extends keyof ParentItem
+        ? ParentItem[ChildArrayName] extends KeyedArray<infer ChildItem>
+            ? Expand<Omit<ParentItem, ChildArrayName | keyof ChildItem> & ChildItem>
+            : never
+        : never;
+
+type TransformWithFlatten<
+    T,
+    Path extends string[],
+    ParentArrayName extends string,
+    OutputArrayName extends string,
+    FlattenedItem
+> = Path extends []
+    ? Expand<Omit<T, ParentArrayName> & Record<OutputArrayName, KeyedArray<FlattenedItem>>>
+    : Expand<
+          TransformAtPath<
+              T,
+              Path,
+              Expand<
+                  Omit<NavigateToPath<T, Path>, ParentArrayName> &
+                  Record<OutputArrayName, KeyedArray<FlattenedItem>>
+              >
+          >
+      >;
+
 /**
  * Replaces an array property with an aggregate property at a specific level.
  */
@@ -602,6 +633,30 @@ export class PipelineBuilder<
             inferredChildArrayName,
             this.scopeSegments as string[]
         );
+        return new PipelineBuilder(this.input, newStep, [] as unknown as Path, this.diagnosticBridge);
+    }
+
+    flatten<
+        ParentArrayName extends ArrayPropertyNameAtCurrentPath<T, Path>,
+        ParentItem extends ArrayItemAtCurrentPath<T, Path, ParentArrayName> = ArrayItemAtCurrentPath<T, Path, ParentArrayName>,
+        ChildArrayName extends ArrayPropertyName<ParentItem> = ArrayPropertyName<ParentItem>,
+        OutputArrayName extends string = string,
+        FlattenedItem extends FlattenMergedItem<ParentItem, ChildArrayName> = FlattenMergedItem<ParentItem, ChildArrayName>
+    >(
+        parentArrayName: ParentArrayName,
+        childArrayName: ChildArrayName,
+        outputArrayName: OutputArrayName
+    ): PipelineBuilder<
+        TransformWithFlatten<T, Path, ParentArrayName, OutputArrayName, FlattenedItem>,
+        TStart,
+        Path,
+        RootScopeName,
+        TSources
+    > {
+        const parentPath = [...this.scopeSegments, parentArrayName];
+        const childPath = [...parentPath, childArrayName];
+        const outputPath = [...this.scopeSegments, outputArrayName];
+        const newStep = new FlattenStep(this.lastStep, parentPath, childPath, outputPath);
         return new PipelineBuilder(this.input, newStep, [] as unknown as Path, this.diagnosticBridge);
     }
 

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -430,10 +430,14 @@ type ArrayPropertyName<T> = {
     [K in keyof T]-?: T[K] extends KeyedArray<unknown> ? K : never
 }[keyof T] & string;
 
+type ParentNonArrayProps<ParentItem> = {
+    [K in keyof ParentItem as ParentItem[K] extends KeyedArray<unknown> ? never : K]: ParentItem[K]
+};
+
 type FlattenMergedItem<ParentItem, ChildArrayName extends string> =
     ChildArrayName extends keyof ParentItem
         ? ParentItem[ChildArrayName] extends KeyedArray<infer ChildItem>
-            ? Expand<Omit<ParentItem, ChildArrayName | keyof ChildItem> & ChildItem>
+            ? Expand<Omit<ParentNonArrayProps<ParentItem>, keyof ChildItem> & ChildItem>
             : never
         : never;
 
@@ -645,7 +649,8 @@ export class PipelineBuilder<
     >(
         parentArrayName: ParentArrayName,
         childArrayName: ChildArrayName,
-        outputArrayName: OutputArrayName
+        outputArrayName: OutputArrayName &
+            (OutputArrayName extends keyof NavigateToPath<T, Path> ? never : unknown)
     ): PipelineBuilder<
         TransformWithFlatten<T, Path, ParentArrayName, OutputArrayName, FlattenedItem>,
         TStart,

--- a/src/steps/flatten.ts
+++ b/src/steps/flatten.ts
@@ -1,0 +1,432 @@
+import type {
+    AddedHandler,
+    DescriptorNode,
+    ImmutableProps,
+    ModifiedHandler,
+    RemovedHandler,
+    ScalarDescriptor,
+    Step,
+    TypeDescriptor
+} from '../pipeline.js';
+import { computeHash } from '../util/hash.js';
+import { pathsMatch, pathStartsWith } from '../util/path.js';
+
+function parentIdentity(outputKeyPath: string[], parentKey: string): string {
+    return JSON.stringify({ outputKeyPath, parentKey });
+}
+
+function compositeChildKey(parentKey: string, childKey: string): string {
+    return computeHash(JSON.stringify([parentKey, childKey]));
+}
+
+function mergeScalarsWithChildPrecedence(
+    parentScalars: ScalarDescriptor[],
+    childScalars: ScalarDescriptor[]
+): ScalarDescriptor[] {
+    const scalarMap = new Map<string, ScalarDescriptor>();
+    parentScalars.forEach(scalar => scalarMap.set(scalar.name, scalar));
+    childScalars.forEach(scalar => scalarMap.set(scalar.name, scalar));
+    return Array.from(scalarMap.values());
+}
+
+function mergeObjectsWithChildPrecedence(
+    parentObjects: DescriptorNode['objects'],
+    childObjects: DescriptorNode['objects']
+): DescriptorNode['objects'] {
+    const objectMap = new Map<string, DescriptorNode['objects'][number]>();
+    parentObjects.forEach(objectDescriptor => objectMap.set(objectDescriptor.name, objectDescriptor));
+    childObjects.forEach(objectDescriptor => objectMap.set(objectDescriptor.name, objectDescriptor));
+    return Array.from(objectMap.values());
+}
+
+function mergedMutableProperties(
+    parentMutableProperties: string[],
+    childMutableProperties: string[],
+    mergedScalars: ScalarDescriptor[]
+): string[] {
+    const scalarNames = new Set(mergedScalars.map(s => s.name));
+    const mutable = new Set<string>();
+    for (const prop of parentMutableProperties) {
+        if (scalarNames.has(prop)) {
+            mutable.add(prop);
+        }
+    }
+    for (const prop of childMutableProperties) {
+        if (scalarNames.has(prop)) {
+            mutable.add(prop);
+        }
+    }
+    return Array.from(mutable);
+}
+
+export class FlattenStep implements Step {
+    private readonly outputAddedHandlers: AddedHandler[] = [];
+    private readonly outputRemovedHandlers: RemovedHandler[] = [];
+    private readonly outputModifiedHandlersByProperty: Map<string, ModifiedHandler[]> = new Map();
+
+    private readonly parentScalarsByParentIdentity: Map<string, ImmutableProps> = new Map();
+    private readonly childKeysByParentIdentity: Map<string, Set<string>> = new Map();
+
+    private readonly scopePath: string[];
+    private readonly parentArrayName: string;
+    private readonly childArrayName: string;
+    private readonly outputArrayName: string;
+    private readonly outputDepth: number;
+
+    constructor(
+        private input: Step,
+        private parentPath: string[],
+        private childPath: string[],
+        private outputPath: string[]
+    ) {
+        if (this.parentPath.length === 0 || this.childPath.length === 0 || this.outputPath.length === 0) {
+            throw new Error('flatten paths must be non-empty');
+        }
+        if (this.childPath.length !== this.parentPath.length + 1) {
+            throw new Error('flatten child path must extend parent path by exactly one segment');
+        }
+
+        this.scopePath = this.outputPath.slice(0, -1);
+        this.parentArrayName = this.parentPath[this.parentPath.length - 1];
+        this.childArrayName = this.childPath[this.childPath.length - 1];
+        this.outputArrayName = this.outputPath[this.outputPath.length - 1];
+        this.outputDepth = this.outputPath.length;
+
+        this.assertValidConfiguration(this.input.getTypeDescriptor());
+
+        this.input.onAdded(this.parentPath, (keyPath, key, immutableProps) => {
+            this.handleParentAdded(keyPath, key, immutableProps);
+        });
+        this.input.onRemoved(this.parentPath, (keyPath, key) => {
+            this.handleParentRemoved(keyPath, key);
+        });
+        this.input.onAdded(this.childPath, (keyPath, key, immutableProps) => {
+            this.handleChildAdded(keyPath, key, immutableProps);
+        });
+        this.input.onRemoved(this.childPath, (keyPath, key, immutableProps) => {
+            this.handleChildRemoved(keyPath, key, immutableProps);
+        });
+
+        const mutableProperties = this.input.getTypeDescriptor().mutableProperties;
+        for (const propertyName of mutableProperties) {
+            this.input.onModified(this.parentPath, propertyName, (keyPath, key, oldValue, newValue) => {
+                this.handleParentModified(keyPath, key, propertyName, oldValue, newValue);
+            });
+            this.input.onModified(this.childPath, propertyName, (keyPath, key, oldValue, newValue) => {
+                this.handleChildModified(keyPath, key, propertyName, oldValue, newValue);
+            });
+        }
+    }
+
+    getTypeDescriptor(): TypeDescriptor {
+        const inputDescriptor = this.input.getTypeDescriptor();
+        this.assertValidConfiguration(inputDescriptor);
+        return {
+            ...this.transformDescriptorAtScope(inputDescriptor, [...this.scopePath]),
+            rootCollectionName: inputDescriptor.rootCollectionName
+        };
+    }
+
+    onAdded(pathSegments: string[], handler: AddedHandler): void {
+        if (pathsMatch(pathSegments, this.outputPath)) {
+            this.outputAddedHandlers.push(handler);
+            return;
+        }
+
+        if (this.isBelowOutputPath(pathSegments)) {
+            const translatedPath = this.translateOutputPathToChildPath(pathSegments);
+            this.input.onAdded(translatedPath, (keyPath, key, immutableProps) => {
+                const rewrittenKeyPath = this.rewriteNestedKeyPath(keyPath);
+                if (rewrittenKeyPath !== null) {
+                    handler(rewrittenKeyPath, key, immutableProps);
+                }
+            });
+            return;
+        }
+
+        this.input.onAdded(pathSegments, handler);
+    }
+
+    onRemoved(pathSegments: string[], handler: RemovedHandler): void {
+        if (pathsMatch(pathSegments, this.outputPath)) {
+            this.outputRemovedHandlers.push(handler);
+            return;
+        }
+
+        if (this.isBelowOutputPath(pathSegments)) {
+            const translatedPath = this.translateOutputPathToChildPath(pathSegments);
+            this.input.onRemoved(translatedPath, (keyPath, key, immutableProps) => {
+                const rewrittenKeyPath = this.rewriteNestedKeyPath(keyPath);
+                if (rewrittenKeyPath !== null) {
+                    handler(rewrittenKeyPath, key, immutableProps);
+                }
+            });
+            return;
+        }
+
+        this.input.onRemoved(pathSegments, handler);
+    }
+
+    onModified(pathSegments: string[], propertyName: string, handler: ModifiedHandler): void {
+        if (pathsMatch(pathSegments, this.outputPath)) {
+            const handlers = this.outputModifiedHandlersByProperty.get(propertyName) ?? [];
+            handlers.push(handler);
+            this.outputModifiedHandlersByProperty.set(propertyName, handlers);
+            return;
+        }
+
+        if (this.isBelowOutputPath(pathSegments)) {
+            const translatedPath = this.translateOutputPathToChildPath(pathSegments);
+            this.input.onModified(translatedPath, propertyName, (keyPath, key, oldValue, newValue) => {
+                const rewrittenKeyPath = this.rewriteNestedKeyPath(keyPath);
+                if (rewrittenKeyPath !== null) {
+                    handler(rewrittenKeyPath, key, oldValue, newValue);
+                }
+            });
+            return;
+        }
+
+        this.input.onModified(pathSegments, propertyName, handler);
+    }
+
+    private assertValidConfiguration(descriptor: TypeDescriptor): void {
+        const scopeNode = this.navigateToScopeNode(descriptor, [...this.scopePath]);
+        if (scopeNode === null) {
+            throw new Error(`flatten scope path is invalid: [${this.scopePath.join('.')}]`);
+        }
+
+        const parentArray = scopeNode.arrays.find(arrayDescriptor => arrayDescriptor.name === this.parentArrayName);
+        if (!parentArray) {
+            throw new Error(`flatten parent array not found at current scope: "${this.parentArrayName}"`);
+        }
+
+        const childArray = parentArray.type.arrays.find(arrayDescriptor => arrayDescriptor.name === this.childArrayName);
+        if (!childArray) {
+            throw new Error(`flatten child array not found within parent array "${this.parentArrayName}": "${this.childArrayName}"`);
+        }
+
+        if (scopeNode.arrays.some(arrayDescriptor => arrayDescriptor.name === this.outputArrayName)) {
+            throw new Error(`flatten output array already exists at current scope: "${this.outputArrayName}"`);
+        }
+    }
+
+    private navigateToScopeNode(node: DescriptorNode, remainingSegments: string[]): DescriptorNode | null {
+        if (remainingSegments.length === 0) {
+            return node;
+        }
+
+        const [segment, ...rest] = remainingSegments;
+        const arrayDescriptor = node.arrays.find(array => array.name === segment);
+        if (!arrayDescriptor) {
+            return null;
+        }
+        return this.navigateToScopeNode(arrayDescriptor.type, rest);
+    }
+
+    private transformDescriptorAtScope(node: DescriptorNode, remainingScopePath: string[]): DescriptorNode {
+        if (remainingScopePath.length === 0) {
+            const parentArray = node.arrays.find(arrayDescriptor => arrayDescriptor.name === this.parentArrayName);
+            if (!parentArray) {
+                return node;
+            }
+            const childArray = parentArray.type.arrays.find(arrayDescriptor => arrayDescriptor.name === this.childArrayName);
+            if (!childArray) {
+                return node;
+            }
+
+            const mergedScalars = mergeScalarsWithChildPrecedence(parentArray.type.scalars, childArray.type.scalars);
+            const flattenedNode: DescriptorNode = {
+                arrays: childArray.type.arrays,
+                collectionKey: [...parentArray.type.collectionKey, ...childArray.type.collectionKey],
+                scalars: mergedScalars,
+                objects: mergeObjectsWithChildPrecedence(parentArray.type.objects, childArray.type.objects),
+                mutableProperties: mergedMutableProperties(
+                    parentArray.type.mutableProperties,
+                    childArray.type.mutableProperties,
+                    mergedScalars
+                )
+            };
+
+            const arrays = node.arrays.map(arrayDescriptor => {
+                if (arrayDescriptor.name === this.parentArrayName) {
+                    return {
+                        name: this.outputArrayName,
+                        type: flattenedNode
+                    };
+                }
+                return arrayDescriptor;
+            });
+
+            return {
+                ...node,
+                arrays
+            };
+        }
+
+        const [segment, ...rest] = remainingScopePath;
+        return {
+            ...node,
+            arrays: node.arrays.map(arrayDescriptor => {
+                if (arrayDescriptor.name !== segment) {
+                    return arrayDescriptor;
+                }
+                return {
+                    ...arrayDescriptor,
+                    type: this.transformDescriptorAtScope(arrayDescriptor.type, rest)
+                };
+            })
+        };
+    }
+
+    private isBelowOutputPath(pathSegments: string[]): boolean {
+        return pathSegments.length > this.outputPath.length && pathStartsWith(pathSegments, this.outputPath);
+    }
+
+    private translateOutputPathToChildPath(pathSegments: string[]): string[] {
+        const suffix = pathSegments.slice(this.outputPath.length);
+        return [...this.childPath, ...suffix];
+    }
+
+    private rewriteNestedKeyPath(keyPath: string[]): string[] | null {
+        if (keyPath.length <= this.outputDepth + 1) {
+            return null;
+        }
+
+        const outputKeyPath = keyPath.slice(0, this.outputDepth);
+        const parentKey = keyPath[this.outputDepth];
+        const childKey = keyPath[this.outputDepth + 1];
+        if (parentKey === undefined || childKey === undefined) {
+            return null;
+        }
+
+        const suffix = keyPath.slice(this.outputDepth + 2);
+        const flatKey = compositeChildKey(parentKey, childKey);
+        return [...outputKeyPath, flatKey, ...suffix];
+    }
+
+    private handleParentAdded(keyPath: string[], parentKey: string, immutableProps: ImmutableProps): void {
+        const id = parentIdentity(keyPath, parentKey);
+        this.parentScalarsByParentIdentity.set(id, immutableProps);
+        if (!this.childKeysByParentIdentity.has(id)) {
+            this.childKeysByParentIdentity.set(id, new Set<string>());
+        }
+    }
+
+    private handleParentRemoved(keyPath: string[], parentKey: string): void {
+        const id = parentIdentity(keyPath, parentKey);
+        this.parentScalarsByParentIdentity.delete(id);
+        this.childKeysByParentIdentity.delete(id);
+    }
+
+    private handleChildAdded(keyPath: string[], childKey: string, childProps: ImmutableProps): void {
+        if (keyPath.length <= this.outputDepth) {
+            return;
+        }
+
+        const outputKeyPath = keyPath.slice(0, this.outputDepth);
+        const parentKey = keyPath[this.outputDepth];
+        if (parentKey === undefined) {
+            return;
+        }
+        const id = parentIdentity(outputKeyPath, parentKey);
+        const parentProps = this.parentScalarsByParentIdentity.get(id) ?? {};
+
+        let childKeys = this.childKeysByParentIdentity.get(id);
+        if (!childKeys) {
+            childKeys = new Set<string>();
+            this.childKeysByParentIdentity.set(id, childKeys);
+        }
+        childKeys.add(childKey);
+
+        const flatKey = compositeChildKey(parentKey, childKey);
+        const mergedProps = { ...parentProps, ...childProps };
+        this.outputAddedHandlers.forEach(handler => {
+            handler(outputKeyPath, flatKey, mergedProps);
+        });
+    }
+
+    private handleChildRemoved(keyPath: string[], childKey: string, childProps: ImmutableProps): void {
+        if (keyPath.length <= this.outputDepth) {
+            return;
+        }
+
+        const outputKeyPath = keyPath.slice(0, this.outputDepth);
+        const parentKey = keyPath[this.outputDepth];
+        if (parentKey === undefined) {
+            return;
+        }
+        const id = parentIdentity(outputKeyPath, parentKey);
+        const parentProps = this.parentScalarsByParentIdentity.get(id) ?? {};
+
+        const childKeys = this.childKeysByParentIdentity.get(id);
+        childKeys?.delete(childKey);
+
+        const flatKey = compositeChildKey(parentKey, childKey);
+        const mergedProps = { ...parentProps, ...childProps };
+        this.outputRemovedHandlers.forEach(handler => {
+            handler(outputKeyPath, flatKey, mergedProps);
+        });
+    }
+
+    private handleParentModified(
+        keyPath: string[],
+        parentKey: string,
+        propertyName: string,
+        oldValue: unknown,
+        newValue: unknown
+    ): void {
+        const id = parentIdentity(keyPath, parentKey);
+        const parentProps = this.parentScalarsByParentIdentity.get(id);
+        if (parentProps) {
+            this.parentScalarsByParentIdentity.set(id, {
+                ...parentProps,
+                [propertyName]: newValue
+            });
+        }
+
+        const childKeys = this.childKeysByParentIdentity.get(id);
+        if (!childKeys || childKeys.size === 0) {
+            return;
+        }
+
+        const handlers = this.outputModifiedHandlersByProperty.get(propertyName);
+        if (!handlers || handlers.length === 0) {
+            return;
+        }
+
+        childKeys.forEach(childKey => {
+            const flatKey = compositeChildKey(parentKey, childKey);
+            handlers.forEach(handler => {
+                handler(keyPath, flatKey, oldValue, newValue);
+            });
+        });
+    }
+
+    private handleChildModified(
+        keyPath: string[],
+        childKey: string,
+        propertyName: string,
+        oldValue: unknown,
+        newValue: unknown
+    ): void {
+        if (keyPath.length <= this.outputDepth) {
+            return;
+        }
+
+        const handlers = this.outputModifiedHandlersByProperty.get(propertyName);
+        if (!handlers || handlers.length === 0) {
+            return;
+        }
+
+        const outputKeyPath = keyPath.slice(0, this.outputDepth);
+        const parentKey = keyPath[this.outputDepth];
+        if (parentKey === undefined) {
+            return;
+        }
+
+        const flatKey = compositeChildKey(parentKey, childKey);
+        handlers.forEach(handler => {
+            handler(outputKeyPath, flatKey, oldValue, newValue);
+        });
+    }
+}

--- a/src/steps/flatten.ts
+++ b/src/steps/flatten.ts
@@ -66,12 +66,14 @@ export class FlattenStep implements Step {
 
     private readonly parentScalarsByParentIdentity: Map<string, ImmutableProps> = new Map();
     private readonly childKeysByParentIdentity: Map<string, Set<string>> = new Map();
+    private readonly childPropertyCountsByParentIdentity: Map<string, Map<string, number>> = new Map();
 
     private readonly scopePath: string[];
     private readonly parentArrayName: string;
     private readonly childArrayName: string;
     private readonly outputArrayName: string;
     private readonly outputDepth: number;
+    private readonly childScalarNames: Set<string>;
 
     constructor(
         private input: Step,
@@ -91,6 +93,7 @@ export class FlattenStep implements Step {
         this.childArrayName = this.childPath[this.childPath.length - 1];
         this.outputArrayName = this.outputPath[this.outputPath.length - 1];
         this.outputDepth = this.outputPath.length;
+        this.childScalarNames = this.getChildScalarNames(this.input.getTypeDescriptor());
 
         this.assertValidConfiguration(this.input.getTypeDescriptor());
 
@@ -210,6 +213,25 @@ export class FlattenStep implements Step {
         }
     }
 
+    private getChildScalarNames(descriptor: TypeDescriptor): Set<string> {
+        const scopeNode = this.navigateToScopeNode(descriptor, [...this.scopePath]);
+        if (!scopeNode) {
+            return new Set<string>();
+        }
+
+        const parentArray = scopeNode.arrays.find(arrayDescriptor => arrayDescriptor.name === this.parentArrayName);
+        if (!parentArray) {
+            return new Set<string>();
+        }
+
+        const childArray = parentArray.type.arrays.find(arrayDescriptor => arrayDescriptor.name === this.childArrayName);
+        if (!childArray) {
+            return new Set<string>();
+        }
+
+        return new Set(childArray.type.scalars.map(scalar => scalar.name));
+    }
+
     private navigateToScopeNode(node: DescriptorNode, remainingSegments: string[]): DescriptorNode | null {
         if (remainingSegments.length === 0) {
             return node;
@@ -316,6 +338,7 @@ export class FlattenStep implements Step {
         const id = parentIdentity(keyPath, parentKey);
         this.parentScalarsByParentIdentity.delete(id);
         this.childKeysByParentIdentity.delete(id);
+        this.childPropertyCountsByParentIdentity.delete(id);
     }
 
     private handleChildAdded(keyPath: string[], childKey: string, childProps: ImmutableProps): void {
@@ -337,6 +360,15 @@ export class FlattenStep implements Step {
             this.childKeysByParentIdentity.set(id, childKeys);
         }
         childKeys.add(childKey);
+
+        let propertyCounts = this.childPropertyCountsByParentIdentity.get(id);
+        if (!propertyCounts) {
+            propertyCounts = new Map<string, number>();
+            this.childPropertyCountsByParentIdentity.set(id, propertyCounts);
+        }
+        for (const propertyName of Object.keys(childProps)) {
+            propertyCounts.set(propertyName, (propertyCounts.get(propertyName) ?? 0) + 1);
+        }
 
         const flatKey = compositeChildKey(parentKey, childKey);
         const mergedProps = { ...parentProps, ...childProps };
@@ -360,6 +392,23 @@ export class FlattenStep implements Step {
 
         const childKeys = this.childKeysByParentIdentity.get(id);
         childKeys?.delete(childKey);
+        const propertyCounts = this.childPropertyCountsByParentIdentity.get(id);
+        if (propertyCounts) {
+            for (const propertyName of Object.keys(childProps)) {
+                const count = propertyCounts.get(propertyName);
+                if (!count) {
+                    continue;
+                }
+                if (count <= 1) {
+                    propertyCounts.delete(propertyName);
+                } else {
+                    propertyCounts.set(propertyName, count - 1);
+                }
+            }
+            if (propertyCounts.size === 0) {
+                this.childPropertyCountsByParentIdentity.delete(id);
+            }
+        }
 
         const flatKey = compositeChildKey(parentKey, childKey);
         const mergedProps = { ...parentProps, ...childProps };
@@ -376,6 +425,11 @@ export class FlattenStep implements Step {
         newValue: unknown
     ): void {
         const id = parentIdentity(keyPath, parentKey);
+        // Child scalar values win on collision. Parent modifications for colliding names
+        // should not fan out to flattened children.
+        if (this.childScalarNames.has(propertyName) || this.parentHasChildProperty(id, propertyName)) {
+            return;
+        }
         const parentProps = this.parentScalarsByParentIdentity.get(id);
         if (parentProps) {
             this.parentScalarsByParentIdentity.set(id, {
@@ -400,6 +454,14 @@ export class FlattenStep implements Step {
                 handler(keyPath, flatKey, oldValue, newValue);
             });
         });
+    }
+
+    private parentHasChildProperty(parentId: string, propertyName: string): boolean {
+        const propertyCounts = this.childPropertyCountsByParentIdentity.get(parentId);
+        if (!propertyCounts) {
+            return false;
+        }
+        return (propertyCounts.get(propertyName) ?? 0) > 0;
     }
 
     private handleChildModified(

--- a/src/test/pipeline.flatten.test.ts
+++ b/src/test/pipeline.flatten.test.ts
@@ -63,6 +63,28 @@ describe('pipeline flatten', () => {
         expect(output[0].flatVenues[0].label).toBe('child-label');
     });
 
+    it('should not overwrite child-colliding scalar values when parent scalar with same name changes', () => {
+        const [pipeline, getOutput] = createTestPipeline(() =>
+            createPipeline<{ state: string; city: string; score: number; one: number }>()
+                .groupBy(['state'], 'states')
+                .in('items').groupBy(['city'], 'cities')
+                .in('cities').sum('items', 'one', 'score')
+                .flatten('cities', 'items', 'flatRows')
+        );
+
+        pipeline.add('r1', { state: 'TX', city: 'Dallas', score: 101, one: 1 });
+        let output = getOutput();
+        expect(output[0].flatRows).toEqual([{ city: 'Dallas', score: 101, one: 1 }]);
+
+        // Adding a second child updates the parent aggregate "score" from 1 -> 2.
+        // Child-level score values should still win on name collision.
+        pipeline.add('r2', { state: 'TX', city: 'Dallas', score: 202, one: 1 });
+        output = getOutput();
+        const scores = sortByJson(output[0].flatRows.map((row: any) => row.score));
+
+        expect(scores).toEqual(sortByJson([101, 202]));
+    });
+
     it('should remove flattened children when children are removed and when a parent is depleted', () => {
         const [pipeline, getOutput] = createTestPipeline(() =>
             createPipeline<VenueRow>()

--- a/src/test/pipeline.flatten.test.ts
+++ b/src/test/pipeline.flatten.test.ts
@@ -1,0 +1,234 @@
+// @ts-nocheck
+import { createPipeline } from '../index';
+import { createTestPipeline } from './helpers';
+
+type VenueRow = {
+    state: string;
+    city: string;
+    venue: string;
+    seats: number;
+};
+
+function sortByJson<T>(items: T[]): T[] {
+    return [...items].sort((a, b) => {
+        const left = JSON.stringify(a);
+        const right = JSON.stringify(b);
+        if (left < right) {
+            return -1;
+        }
+        if (left > right) {
+            return 1;
+        }
+        return 0;
+    });
+}
+
+describe('pipeline flatten', () => {
+    it('should emit one flattened item per parent-child pair and preserve scope scalars', () => {
+        const [pipeline, getOutput] = createTestPipeline(() =>
+            createPipeline<VenueRow>()
+                .groupBy(['state'], 'states')
+                .in('items').groupBy(['city'], 'cities')
+                .flatten('cities', 'items', 'flatVenues')
+        );
+
+        pipeline.add('v1', { state: 'TX', city: 'Dallas', venue: 'Stadium', seats: 50000 });
+        pipeline.add('v2', { state: 'TX', city: 'Dallas', venue: 'Arena', seats: 20000 });
+        pipeline.add('v3', { state: 'TX', city: 'Houston', venue: 'Center', seats: 30000 });
+
+        const output = getOutput();
+        expect(output).toHaveLength(1);
+        expect(output[0].state).toBe('TX');
+        expect(output[0].flatVenues).toHaveLength(3);
+        expect(sortByJson(output[0].flatVenues)).toEqual(sortByJson([
+            { city: 'Dallas', venue: 'Stadium', seats: 50000 },
+            { city: 'Dallas', venue: 'Arena', seats: 20000 },
+            { city: 'Houston', venue: 'Center', seats: 30000 }
+        ]));
+    });
+
+    it('should prefer child scalar values when parent and child scalar names collide', () => {
+        const [pipeline, getOutput] = createTestPipeline(() =>
+            createPipeline<{ state: string; city: string; label: string; venue: string; seats: number }>()
+                .groupBy(['state'], 'states')
+                .in('items').groupBy(['city'], 'cities')
+                .in('cities').defineProperty('label', city => `parent-${city.city}`)
+                .flatten('cities', 'items', 'flatVenues')
+        );
+
+        pipeline.add('v1', { state: 'TX', city: 'Dallas', label: 'child-label', venue: 'Stadium', seats: 50000 });
+        const output = getOutput();
+
+        expect(output[0].flatVenues).toHaveLength(1);
+        expect(output[0].flatVenues[0].label).toBe('child-label');
+    });
+
+    it('should remove flattened children when children are removed and when a parent is depleted', () => {
+        const [pipeline, getOutput] = createTestPipeline(() =>
+            createPipeline<VenueRow>()
+                .groupBy(['state'], 'states')
+                .in('items').groupBy(['city'], 'cities')
+                .flatten('cities', 'items', 'flatVenues')
+        );
+
+        const d1 = { state: 'TX', city: 'Dallas', venue: 'Stadium', seats: 50000 };
+        const d2 = { state: 'TX', city: 'Dallas', venue: 'Arena', seats: 20000 };
+        const h1 = { state: 'TX', city: 'Houston', venue: 'Center', seats: 30000 };
+        pipeline.add('d1', d1);
+        pipeline.add('d2', d2);
+        pipeline.add('h1', h1);
+        expect(getOutput()[0].flatVenues).toHaveLength(3);
+
+        pipeline.remove('d2', d2);
+        let output = getOutput();
+        expect(output[0].flatVenues).toHaveLength(2);
+        expect(output[0].flatVenues.some(v => v.venue === 'Arena')).toBe(false);
+
+        pipeline.remove('d1', d1);
+        output = getOutput();
+        expect(output[0].flatVenues).toHaveLength(1);
+        expect(output[0].flatVenues[0].venue).toBe('Center');
+    });
+
+    it('should fan out parent mutable property changes to all flattened children', () => {
+        const [pipeline, getOutput] = createTestPipeline(() =>
+            createPipeline<VenueRow>()
+                .groupBy(['state'], 'states')
+                .in('items').groupBy(['city'], 'cities')
+                .in('cities').sum('items', 'seats', 'citySeats')
+                .flatten('cities', 'items', 'flatVenues')
+        );
+
+        pipeline.add('v1', { state: 'TX', city: 'Dallas', venue: 'Stadium', seats: 10 });
+        let output = getOutput();
+        expect(output[0].flatVenues).toEqual([{ city: 'Dallas', venue: 'Stadium', seats: 10, citySeats: 10 }]);
+
+        pipeline.add('v2', { state: 'TX', city: 'Dallas', venue: 'Arena', seats: 5 });
+        output = getOutput();
+
+        const flatVenues = sortByJson(output[0].flatVenues);
+        expect(flatVenues).toEqual(sortByJson([
+            { city: 'Dallas', venue: 'Stadium', seats: 10, citySeats: 15 },
+            { city: 'Dallas', venue: 'Arena', seats: 5, citySeats: 15 }
+        ]));
+    });
+
+    it('should apply child mutable property changes only to the corresponding flattened item', () => {
+        const [pipeline, getOutput] = createTestPipeline(() =>
+            createPipeline<VenueRow>()
+                .groupBy(['state'], 'states')
+                .in('items').groupBy(['city'], 'cities')
+                .in('cities', 'items').groupBy(['venue'], 'venues')
+                .in('cities', 'venues').sum('items', 'seats', 'venueSeats')
+                .flatten('cities', 'venues', 'flatVenues')
+        );
+
+        pipeline.add('a1', { state: 'TX', city: 'Dallas', venue: 'A', seats: 10 });
+        pipeline.add('b1', { state: 'TX', city: 'Dallas', venue: 'B', seats: 20 });
+        let output = getOutput();
+        let flat = sortByJson(output[0].flatVenues.map((v: any) => ({
+            city: v.city,
+            venue: v.venue,
+            venueSeats: v.venueSeats
+        })));
+        expect(flat).toEqual(sortByJson([
+            { city: 'Dallas', venue: 'A', venueSeats: 10 },
+            { city: 'Dallas', venue: 'B', venueSeats: 20 }
+        ]));
+
+        pipeline.add('a2', { state: 'TX', city: 'Dallas', venue: 'A', seats: 5 });
+        output = getOutput();
+        flat = sortByJson(output[0].flatVenues.map((v: any) => ({
+            city: v.city,
+            venue: v.venue,
+            venueSeats: v.venueSeats
+        })));
+        expect(flat).toEqual(sortByJson([
+            { city: 'Dallas', venue: 'A', venueSeats: 15 },
+            { city: 'Dallas', venue: 'B', venueSeats: 20 }
+        ]));
+    });
+
+    it('should produce identical final output across different insertion orders', () => {
+        const createAndRun = (rows: Array<{ key: string; value: VenueRow }>) => {
+            const [pipeline, getOutput] = createTestPipeline(() =>
+                createPipeline<VenueRow>()
+                    .groupBy(['state'], 'states')
+                    .in('items').groupBy(['city'], 'cities')
+                    .flatten('cities', 'items', 'flatVenues')
+            );
+
+            rows.forEach(row => pipeline.add(row.key, row.value));
+            return sortByJson(getOutput());
+        };
+
+        const rowsA = [
+            { key: 'v1', value: { state: 'TX', city: 'Dallas', venue: 'Stadium', seats: 50000 } },
+            { key: 'v2', value: { state: 'TX', city: 'Houston', venue: 'Center', seats: 30000 } },
+            { key: 'v3', value: { state: 'CA', city: 'LA', venue: 'Forum', seats: 18000 } }
+        ];
+        const rowsB = [rowsA[2], rowsA[0], rowsA[1]];
+
+        expect(createAndRun(rowsA)).toEqual(createAndRun(rowsB));
+    });
+
+    it('should revert to prior state after adding then removing the same child', () => {
+        const [pipeline, getOutput] = createTestPipeline(() =>
+            createPipeline<VenueRow>()
+                .groupBy(['state'], 'states')
+                .in('items').groupBy(['city'], 'cities')
+                .flatten('cities', 'items', 'flatVenues')
+        );
+
+        pipeline.add('v1', { state: 'TX', city: 'Dallas', venue: 'Stadium', seats: 50000 });
+        const baseline = sortByJson(getOutput());
+
+        const transient = { state: 'TX', city: 'Dallas', venue: 'Arena', seats: 20000 };
+        pipeline.add('transient', transient);
+        pipeline.remove('transient', transient);
+
+        expect(sortByJson(getOutput())).toEqual(baseline);
+    });
+
+    it('should reject invalid flatten configuration when referenced arrays do not exist', () => {
+        expect(() => (createPipeline<{ state: string }>() as any)
+            .flatten('cities', 'items', 'flatVenues'))
+            .toThrow();
+
+        expect(() => createPipeline<VenueRow>()
+            .groupBy(['state'], 'states')
+            .flatten('states', 'missing', 'flatVenues'))
+            .toThrow();
+    });
+
+    it('should reject flatten configuration when output array collides at current scope', () => {
+        expect(() => createPipeline<VenueRow>()
+            .groupBy(['state'], 'states')
+            .flatten('states', 'items', 'states'))
+            .toThrow();
+    });
+
+    it('should replace parent array in descriptor and merge child/parent metadata', () => {
+        const descriptor = createPipeline<VenueRow, 'items'>('items', [
+            { name: 'state', type: 'string' },
+            { name: 'city', type: 'string' },
+            { name: 'venue', type: 'string' },
+            { name: 'seats', type: 'number' }
+        ])
+            .groupBy(['state'], 'states')
+            .in('items').groupBy(['city'], 'cities')
+            .in('cities').sum('items', 'seats', 'citySeats')
+            .flatten('cities', 'items', 'flatVenues')
+            .getTypeDescriptor();
+
+        expect(descriptor.scalars).toContainEqual({ name: 'state', type: 'string' });
+        expect(descriptor.arrays.some(a => a.name === 'cities')).toBe(false);
+        expect(descriptor.arrays.some(a => a.name === 'flatVenues')).toBe(true);
+
+        const flattenedType = descriptor.arrays.find(a => a.name === 'flatVenues')!.type;
+        expect(flattenedType.collectionKey).toEqual(['city']);
+        expect(flattenedType.scalars.map(s => s.name)).toEqual(
+            expect.arrayContaining(['city', 'venue', 'seats'])
+        );
+    });
+});

--- a/src/test/pipeline.flatten.type.test-d.ts
+++ b/src/test/pipeline.flatten.type.test-d.ts
@@ -1,0 +1,39 @@
+import { expectError } from 'tsd';
+import { createPipeline, type KeyedArray, type PipelineOutput } from '../index.js';
+
+type NestedInput = {
+    states: KeyedArray<{
+        state: string;
+        cities: KeyedArray<{
+            city: string;
+            venue: string;
+            seats: number;
+        }>;
+        parentNotes: KeyedArray<{ note: string }>;
+    }>;
+};
+
+{
+    const builder = createPipeline<NestedInput>()
+        .flatten('states', 'cities', 'flatCities');
+
+    type Output = PipelineOutput<typeof builder>;
+    type FlatCity = Output['flatCities'][number]['value'];
+
+    // Issue #2: should be a type error if sibling parent arrays leak into flattened item type.
+    expectError(({} as FlatCity).parentNotes);
+}
+
+{
+    // Issue #4: output name collision with an existing scalar at scope should be rejected.
+    expectError(
+        createPipeline<{
+            flatCities: string;
+            states: KeyedArray<{
+                state: string;
+                cities: KeyedArray<{ city: string }>;
+            }>;
+        }>().flatten('states', 'cities', 'flatCities')
+    );
+}
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `FlattenStep` and `PipelineBuilder.flatten(...)` implementation with runtime + descriptor behavior
- add flatten behavior tests in `src/test/pipeline.flatten.test.ts`
- add follow-up review-driven tests:
  - runtime test for parent/child colliding scalar precedence under parent modification fan-out (issue #1)
  - type tests in `src/test/pipeline.flatten.type.test-d.ts` for:
    - sibling parent-array leakage in flattened item type (issue #2)
    - output-name collision with existing scalar at scope (issue #4)
- fix implementation to satisfy new tests:
  - runtime precedence fix for parent-vs-child colliding properties
  - type fix #2: flatten merged item omits parent `KeyedArray` properties
  - type fix #4: `flatten` builder signature rejects colliding output names

## Rebase
- rebased branch onto latest `timeline-aggregate`
- resolved conflict in `src/builder.ts` by keeping both incoming step APIs and the flatten type/runtime fixes

## Verification
- `npm test -- --runInBand src/test/pipeline.flatten.test.ts`
- `npm run test:types -- --files "src/test/pipeline.flatten.type.test-d.ts"`
- `npm run build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f90bdf68-1917-49b6-89cb-089ee5f54dc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f90bdf68-1917-49b6-89cb-089ee5f54dc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

