### PR TITLE
Enforce type-safe pipeline state contracts

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -391,6 +391,14 @@ type ArrayItemAtCurrentPath<
     ? ItemType
     : never;
 
+type ArrayItemImmutablePropsAtCurrentPath<
+    T,
+    Path extends string[],
+    ArrayName extends ArrayPropertyNameAtCurrentPath<T, Path>
+> = ArrayItemAtCurrentPath<T, Path, ArrayName> extends ImmutableProps
+    ? ArrayItemAtCurrentPath<T, Path, ArrayName>
+    : never;
+
 type ArrayPropertyNameOn<T> = {
     [K in keyof T]-?: T[K] extends KeyedArray<unknown> ? K : never
 }[keyof T] & string;
@@ -552,7 +560,7 @@ export class PipelineBuilder<
     constructor(
         private rootBuilder: StepBuilder,
         private lastBuilder: StepBuilder,
-        private scopeSegments: Path = [] as unknown as Path,
+        private scopeSegments: string[] = [],
         private diagnosticBridge: DeferredDiagnosticBridge = createDeferredDiagnosticBridge()
     ) {}
 
@@ -584,10 +592,10 @@ export class PipelineBuilder<
             this.lastBuilder,
             propertyName,
             compute as (item: unknown) => U,
-            this.scopeSegments as string[],
+            this.scopeSegments,
             mutableProperties
         );
-        return new PipelineBuilder(this.rootBuilder, newBuilder, [] as unknown as Path, this.diagnosticBridge);
+        return new PipelineBuilder(this.rootBuilder, newBuilder, [], this.diagnosticBridge);
     }
 
     dropProperty<K extends keyof NavigateToPath<T, Path>>(propertyName: K): PipelineBuilder<
@@ -602,9 +610,9 @@ export class PipelineBuilder<
         const newBuilder = new DropPropertyBuilder(
             this.lastBuilder,
             propertyName as string,
-            this.scopeSegments as string[]
+            this.scopeSegments
         );
-        return new PipelineBuilder(this.rootBuilder, newBuilder, [] as unknown as Path, this.diagnosticBridge);
+        return new PipelineBuilder(this.rootBuilder, newBuilder, [], this.diagnosticBridge);
     }
 
     groupBy<K extends keyof NavigateToPath<T, Path>, ArrayName extends string>(
@@ -629,9 +637,9 @@ export class PipelineBuilder<
             groupingProperties as string[],
             arrayName,
             inferredChildArrayName,
-            this.scopeSegments as string[]
+            this.scopeSegments
         );
-        return new PipelineBuilder(this.rootBuilder, newBuilder, [] as unknown as Path, this.diagnosticBridge);
+        return new PipelineBuilder(this.rootBuilder, newBuilder, [], this.diagnosticBridge);
     }
 
     flatten<
@@ -658,7 +666,7 @@ export class PipelineBuilder<
         const newBuilder = new FlattenBuilder(this.lastBuilder, parentPath, childPath, outputPath);
         // Preserve definition-time validation semantics for invalid flatten configurations.
         newBuilder.getTypeDescriptor();
-        return new PipelineBuilder(this.rootBuilder, newBuilder, [] as unknown as Path, this.diagnosticBridge);
+        return new PipelineBuilder(this.rootBuilder, newBuilder, [], this.diagnosticBridge);
     }
 
     /*
@@ -719,8 +727,8 @@ export class PipelineBuilder<
     >(
         arrayName: ArrayName,
         propertyName: PropName,
-        add: AddOperator<ArrayItemAtCurrentPath<T, Path, ArrayName>, TAggregate>,
-        subtract: SubtractOperator<ArrayItemAtCurrentPath<T, Path, ArrayName>, TAggregate>,
+        add: AddOperator<ArrayItemImmutablePropsAtCurrentPath<T, Path, ArrayName>, TAggregate>,
+        subtract: SubtractOperator<ArrayItemImmutablePropsAtCurrentPath<T, Path, ArrayName>, TAggregate>,
         propertyToAggregate?: string
     ): PipelineBuilder<
         Path extends []
@@ -732,17 +740,17 @@ export class PipelineBuilder<
         TSources
     > {
         const fullSegmentPath = [...this.scopeSegments, arrayName];
-        const newBuilder = new CommutativeAggregateBuilder(
+        const newBuilder = new CommutativeAggregateBuilder<ArrayItemImmutablePropsAtCurrentPath<T, Path, ArrayName>, TAggregate>(
             this.lastBuilder,
             fullSegmentPath,
             propertyName,
             {
-                add: add as AddOperator<ImmutableProps, TAggregate>,
-                subtract: subtract as SubtractOperator<ImmutableProps, TAggregate>
+                add,
+                subtract
             },
             propertyToAggregate
         );
-        return new PipelineBuilder(this.rootBuilder, newBuilder, [] as unknown as Path, this.diagnosticBridge);
+        return new PipelineBuilder(this.rootBuilder, newBuilder, [], this.diagnosticBridge);
     }
 
     cumulativeSum<
@@ -882,7 +890,7 @@ export class PipelineBuilder<
             propertyName,
             (left, right) => left - right
         );
-        return new PipelineBuilder(this.rootBuilder, newBuilder, [] as unknown as Path, this.diagnosticBridge);
+        return new PipelineBuilder(this.rootBuilder, newBuilder, [], this.diagnosticBridge);
     }
     
     /**
@@ -921,7 +929,7 @@ export class PipelineBuilder<
             propertyName,
             (left, right) => right - left
         );
-        return new PipelineBuilder(this.rootBuilder, newBuilder, [] as unknown as Path, this.diagnosticBridge);
+        return new PipelineBuilder(this.rootBuilder, newBuilder, [], this.diagnosticBridge);
     }
 
     replaceToDelta<
@@ -966,7 +974,7 @@ export class PipelineBuilder<
         );
         // Preserve definition-time validation semantics for invalid replaceToDelta configuration.
         newBuilder.getTypeDescriptor();
-        return new PipelineBuilder(this.rootBuilder, newBuilder, [] as unknown as Path, this.diagnosticBridge);
+        return new PipelineBuilder(this.rootBuilder, newBuilder, [], this.diagnosticBridge);
     }
     
     /**
@@ -1004,7 +1012,7 @@ export class PipelineBuilder<
             outputProperty,
             propertyName
         );
-        return new PipelineBuilder(this.rootBuilder, newBuilder, [] as unknown as Path, this.diagnosticBridge);
+        return new PipelineBuilder(this.rootBuilder, newBuilder, [], this.diagnosticBridge);
     }
     
     /**
@@ -1044,7 +1052,7 @@ export class PipelineBuilder<
             propertyName,
             compareMixedPrimitiveValues
         );
-        return new PipelineBuilder(this.rootBuilder, newBuilder, [] as unknown as Path, this.diagnosticBridge);
+        return new PipelineBuilder(this.rootBuilder, newBuilder, [], this.diagnosticBridge);
     }
     
     /**
@@ -1084,7 +1092,7 @@ export class PipelineBuilder<
             propertyName,
             (left, right) => compareMixedPrimitiveValues(right, left)
         );
-        return new PipelineBuilder(this.rootBuilder, newBuilder, [] as unknown as Path, this.diagnosticBridge);
+        return new PipelineBuilder(this.rootBuilder, newBuilder, [], this.diagnosticBridge);
     }
     
     /**
@@ -1126,7 +1134,7 @@ export class PipelineBuilder<
         const newBuilder = new FilterBuilder(
             this.lastBuilder,
             predicate as (item: unknown) => boolean,
-            this.scopeSegments as string[],
+            this.scopeSegments,
             mutableProperties
         );
         return new PipelineBuilder(this.rootBuilder, newBuilder, this.scopeSegments, this.diagnosticBridge);
@@ -1167,7 +1175,7 @@ export class PipelineBuilder<
             this.lastBuilder,
             sourceName,
             secondaryPipeline.lastBuilder,
-            this.scopeSegments as string[],
+            this.scopeSegments,
             [...primaryKey],
             as,
             whenMissing as ImmutableProps | undefined
@@ -1310,6 +1318,15 @@ function createKeyToIndexMap<T>(state: KeyedArray<T>): Map<string, number> {
     return keyToIndex;
 }
 
+function getChildKeyedArray(value: unknown, segment: string): KeyedArray<unknown> {
+    if (typeof value !== 'object' || value === null) {
+        return [];
+    }
+    const record = value as Record<string, unknown>;
+    const candidate = record[segment];
+    return Array.isArray(candidate) ? (candidate as KeyedArray<unknown>) : [];
+}
+
 function addToKeyedArray<T>(
     state: KeyedArray<T>,
     segmentPath: string[],
@@ -1351,10 +1368,8 @@ function addToKeyedArray<T>(
             return state;
         }
         const existingItem = state[existingItemIndex];
-        // Dynamic property access: segment is used as a property key at runtime
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Runtime hierarchical structure manipulation
-        const value = existingItem.value as Record<string, any>;
-        const existingArray = (value[segment] as KeyedArray<unknown>) || [];
+        const value = existingItem.value as ImmutableProps;
+        const existingArray = getChildKeyedArray(value, segment);
         const modifiedArray = addToKeyedArray(
             existingArray,
             segmentPath.slice(1),
@@ -1419,10 +1434,8 @@ function removeFromKeyedArray<T>(
             return state;
         }
         const existingItem = state[existingItemIndex];
-        // Dynamic property access: segment is used as a property key at runtime
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Runtime hierarchical structure manipulation
-        const value = existingItem.value as Record<string, any>;
-        const existingArray = (value[segment] as KeyedArray<unknown>) || [];
+        const value = existingItem.value as ImmutableProps;
+        const existingArray = getChildKeyedArray(value, segment);
         const modifiedArray = removeFromKeyedArray(
             existingArray,
             segmentPath.slice(1),
@@ -1479,8 +1492,7 @@ function modifyInKeyedArray<T>(
             return state;
         }
         const existingItem = state[existingItemIndex];
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Runtime hierarchical structure manipulation
-        const existingValue = existingItem.value as Record<string, any>;
+        const existingValue = existingItem.value as ImmutableProps;
         const modifiedItem = {
             key: key,
             value: {
@@ -1520,10 +1532,8 @@ function modifyInKeyedArray<T>(
             return state;
         }
         const existingItem = state[existingItemIndex];
-        // Dynamic property access: segment is used as a property key at runtime
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Runtime hierarchical structure manipulation
-        const existingValue = existingItem.value as Record<string, any>;
-        const existingArray = (existingValue[segment] as KeyedArray<unknown>) || [];
+        const existingValue = existingItem.value as ImmutableProps;
+        const existingArray = getChildKeyedArray(existingValue, segment);
         const modifiedArray = modifyInKeyedArray(
             existingArray,
             segmentPath.slice(1),

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -55,8 +55,8 @@ export class InputStep<T, TSources extends Record<string, unknown> = EmptySource
         // No modifications at the input step.
     }
 
-    setSources(sources: Record<string, SourceBindableInput<unknown, Record<string, unknown>>>): void {
-        this.sources = sources as unknown as PipelineSources<TSources>;
+    setSources(sources: PipelineSources<TSources>): void {
+        this.sources = sources;
     }
 }
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -7,7 +7,7 @@ export type PipelineSources<TSources extends Record<string, unknown>> = {
                 TSourcePrimary,
                 TSourceChildren extends Record<string, unknown> ? TSourceChildren : EmptySources
             >
-            : never;
+            : PipelineInput<unknown, Record<string, unknown>>;
 };
 
 export interface PipelineInput<T, TSources extends Record<string, unknown> = EmptySources> {
@@ -18,7 +18,7 @@ export interface PipelineInput<T, TSources extends Record<string, unknown> = Emp
 
 export interface SourceBindableInput<T, TSources extends Record<string, unknown> = EmptySources>
     extends PipelineInput<T, TSources> {
-    setSources(sources: Record<string, SourceBindableInput<unknown, Record<string, unknown>>>): void;
+    setSources(sources: PipelineSources<TSources>): void;
 }
 
 export interface PipelineRuntimeDiagnostic {
@@ -176,7 +176,7 @@ export interface Step {
 export interface BuiltStepGraph {
     rootInput: SourceBindableInput<unknown, Record<string, unknown>>;
     lastStep: Step;
-    sources: Record<string, SourceBindableInput<unknown, Record<string, unknown>>>;
+    sources: PipelineSources<Record<string, unknown>>;
 }
 
 export interface BuildContext {

--- a/src/steps/average-aggregate.ts
+++ b/src/steps/average-aggregate.ts
@@ -38,7 +38,6 @@ function transformAverageAggregateDescriptor(
 interface AverageState {
     sum: number;
     count: number;
-    average: number | undefined;
 }
 
 /**
@@ -63,9 +62,6 @@ export class AverageAggregateStep<
         propertyName: string;
         handler: ModifiedHandler;
     }> = [];
-    
-    /** Maps parent key path hash to current average value (for oldValue tracking) */
-    private aggregateValues: Map<string, number | undefined> = new Map();
     
     /** Whether the property being aggregated is mutable (auto-detected) */
     private isPropertyMutable: boolean = false;
@@ -168,19 +164,17 @@ export class AverageAggregateStep<
                 this.itemValues.get(parentKeyHash)!.set(itemKey, numValue);
                 
                 // Update sum and count
-                const state = this.averageStates.get(parentKeyHash) || { sum: 0, count: 0, average: undefined };
+                const state = this.averageStates.get(parentKeyHash) || { sum: 0, count: 0 };
                 state.sum += numValue;
                 state.count += 1;
-                state.average = state.sum / state.count;
                 this.averageStates.set(parentKeyHash, state);
             }
         }
         
         // Compute new average
         const state = this.averageStates.get(parentKeyHash);
-        const oldAverage = this.aggregateValues.get(parentKeyHash);
-        const newAverage = (state && state.count > 0) ? state.average : undefined;
-        this.aggregateValues.set(parentKeyHash, newAverage);
+        const oldAverage = this.getAverageForParent(parentKeyHash);
+        const newAverage = (state && state.count > 0) ? state.sum / state.count : undefined;
         
         // Emit modification event
         if (parentKeyPath.length > 0) {
@@ -229,11 +223,11 @@ export class AverageAggregateStep<
         // Get or create state
         let state = this.averageStates.get(parentKeyHash);
         if (!state) {
-            state = { sum: 0, count: 0, average: undefined };
+            state = { sum: 0, count: 0 };
             this.averageStates.set(parentKeyHash, state);
         }
         
-        const oldAverage = state.average;
+        const oldAverage = this.getAverageForState(state);
         
         // Update sum and count based on what changed
         if (hadOldValue && hasNewValue) {
@@ -250,20 +244,11 @@ export class AverageAggregateStep<
         }
         
         // Calculate new average
-        if (state.count > 0) {
-            state.average = state.sum / state.count;
-        } else {
-            state.average = undefined;
+        if (state.count <= 0) {
             this.averageStates.delete(parentKeyHash);
         }
         
-        // Update aggregate values cache
-        const newAverage = state.average;
-        if (newAverage !== undefined) {
-            this.aggregateValues.set(parentKeyHash, newAverage);
-        } else {
-            this.aggregateValues.delete(parentKeyHash);
-        }
+        const newAverage = this.getAverageForParent(parentKeyHash);
         
         // Emit modification event
         if (parentKeyPath.length > 0) {
@@ -319,10 +304,9 @@ export class AverageAggregateStep<
                 state.count -= 1;
                 
                 if (state.count === 0) {
-                    state.average = undefined;
                     this.averageStates.delete(parentKeyHash);
-                } else {
-                    state.average = state.sum / state.count;
+                }
+                else {
                     this.averageStates.set(parentKeyHash, state);
                 }
             }
@@ -330,14 +314,8 @@ export class AverageAggregateStep<
         
         // Compute new average
         const state = this.averageStates.get(parentKeyHash);
-        const oldAverage = this.aggregateValues.get(parentKeyHash);
-        const newAverage = (state && state.count > 0) ? state.average : undefined;
-        
-        if (!state || state.count === 0) {
-            this.aggregateValues.delete(parentKeyHash);
-        } else {
-            this.aggregateValues.set(parentKeyHash, newAverage);
-        }
+        const oldAverage = this.getAverageForParent(parentKeyHash);
+        const newAverage = (state && state.count > 0) ? state.sum / state.count : undefined;
         
         // Emit modification event
         if (parentKeyPath.length > 0) {
@@ -352,6 +330,17 @@ export class AverageAggregateStep<
                 handler([], '', oldAverage, newAverage);
             });
         }
+    }
+
+    private getAverageForState(state: AverageState | undefined): number | undefined {
+        if (!state || state.count <= 0) {
+            return undefined;
+        }
+        return state.sum / state.count;
+    }
+
+    private getAverageForParent(parentKeyHash: string): number | undefined {
+        return this.getAverageForState(this.averageStates.get(parentKeyHash));
     }
 }
 

--- a/src/steps/commutative-aggregate.ts
+++ b/src/steps/commutative-aggregate.ts
@@ -27,7 +27,7 @@ export type SubtractOperator<TItem, TAggregate> = (
 /**
  * Configuration for the commutative aggregate operation.
  */
-interface CommutativeAggregateConfig<TItem, TAggregate> {
+interface CommutativeAggregateConfig<TItem extends ImmutableProps, TAggregate> {
     /** Operator called when an item is added */
     add: AddOperator<TItem, TAggregate>;
     
@@ -90,7 +90,8 @@ export class CommutativeAggregateStep<
     _TInput,
     TPath extends string[],
     TPropertyName extends string,
-    TAggregate
+    TAggregate,
+    TItem extends ImmutableProps = ImmutableProps
 > implements Step {
     
     /** Maps parent key path hash to current aggregate value */
@@ -113,7 +114,7 @@ export class CommutativeAggregateStep<
         private input: Step,
         private segmentPath: TPath,
         private propertyName: TPropertyName,
-        private config: CommutativeAggregateConfig<ImmutableProps, TAggregate>,
+        private config: CommutativeAggregateConfig<TItem, TAggregate>,
         private propertyToAggregate: string | undefined,
         inputDescriptor?: TypeDescriptor
     ) {
@@ -216,7 +217,7 @@ export class CommutativeAggregateStep<
         
         // Compute new aggregate
         const currentAggregate = this.aggregateValues.get(parentKeyHash);
-        const newAggregate = this.config.add(currentAggregate, item);
+        const newAggregate = this.config.add(currentAggregate, item as TItem);
         this.aggregateValues.set(parentKeyHash, newAggregate);
         
         // Emit modification event
@@ -254,7 +255,7 @@ export class CommutativeAggregateStep<
         // (oldValue is undefined, no aggregate yet)
         if (currentAggregate === undefined && oldValue === undefined) {
             // This is the initial value for the property - treat as a fresh add
-            const newItem = { [propertyName]: newValue } as ImmutableProps;
+            const newItem = { [propertyName]: newValue } as TItem;
             const newAggregate = this.config.add(undefined, newItem);
             this.aggregateValues.set(parentKeyHash, newAggregate);
             
@@ -287,8 +288,8 @@ export class CommutativeAggregateStep<
         // This works because sum/count operators extract item[propertyName].
         
         // Create pseudo-items with the old and new values
-        const oldItem = { [propertyName]: oldValue } as ImmutableProps;
-        const newItem = { [propertyName]: newValue } as ImmutableProps;
+        const oldItem = { [propertyName]: oldValue } as TItem;
+        const newItem = { [propertyName]: newValue } as TItem;
         
         // Compute new aggregate: subtract old value, add new value
         const intermediateAggregate = this.config.subtract(currentAggregate, oldItem);
@@ -327,7 +328,7 @@ export class CommutativeAggregateStep<
         }
         
         // Compute new aggregate
-        const newAggregate = this.config.subtract(currentAggregate, item);
+        const newAggregate = this.config.subtract(currentAggregate, item as TItem);
         
         // Update item count and clean up if no items remain
         const currentCount = this.itemCounts.get(parentKeyHash) ?? 0;
@@ -357,14 +358,14 @@ export class CommutativeAggregateStep<
     }
 }
 
-export class CommutativeAggregateBuilder<TAggregate> implements StepBuilder {
+export class CommutativeAggregateBuilder<TItem extends ImmutableProps, TAggregate> implements StepBuilder {
     constructor(
         readonly upstream: StepBuilder,
         private segmentPath: string[],
         private propertyName: string,
         private config: {
-            add: AddOperator<ImmutableProps, TAggregate>;
-            subtract: SubtractOperator<ImmutableProps, TAggregate>;
+            add: AddOperator<TItem, TAggregate>;
+            subtract: SubtractOperator<TItem, TAggregate>;
         },
         private propertyToAggregate?: string
     ) {

--- a/src/steps/group-by.ts
+++ b/src/steps/group-by.ts
@@ -115,24 +115,24 @@ export class GroupByStep<
     ParentArrayName extends string,
     ChildArrayName extends string = ParentArrayName
 > implements Step {
+    /**
+     * Item-level state keyed by input item key.
+     * This is the single source of truth for per-item grouping placement.
+     */
+    private itemStates: Map<string, {
+        parentKeyPath: string[];
+        groupKey: string;
+        compositeKey: string;
+        immutableProps: ImmutableProps;
+        groupingValues: ImmutableProps;
+    }> = new Map();
+
     groupAddedHandlers: AddedHandler[] = [];
     itemAddedHandlers: AddedHandler[] = [];
     groupRemovedHandlers: RemovedHandler[] = [];
     itemRemovedHandlers: RemovedHandler[] = [];
-
-    itemKeyToGroupKey: Map<string, string> = new Map<string, string>();
     // Maps composite key (parent path + group key) to item keys - tracks groups per parent context
     groupKeyToItemKeys: Map<string, Set<string>> = new Map<string, Set<string>>();
-    
-    // Maps item key to its parent key path for correct emission
-    itemKeyToParentKeyPath: Map<string, string[]> = new Map<string, string[]>();
-    // Maps item key to its composite key for removal
-    itemKeyToCompositeKey: Map<string, string> = new Map<string, string>();
-    
-    // Maps item key to its full immutable props (for re-grouping)
-    itemKeyToImmutableProps: Map<string, ImmutableProps> = new Map<string, ImmutableProps>();
-    // Maps item key to its current grouping values (for re-grouping)
-    itemKeyToGroupingValues: Map<string, ImmutableProps> = new Map<string, ImmutableProps>();
 
     private readonly childArrayName: ChildArrayName;
     constructor(
@@ -184,14 +184,14 @@ export class GroupByStep<
             this.input.onAdded([...this.scopeSegments, ...shiftedSegments], (notifiedKeyPath, itemKey, immutableProps) => {
                 // notifiedKeyPath is relative to scopeSegments, element at scopeSegments.length is the item key
                 const itemKeyAtScope = notifiedKeyPath[this.scopeSegments.length];
-                const groupKey = this.itemKeyToGroupKey.get(itemKeyAtScope);
-                if (groupKey === undefined) {
+                const itemState = this.itemStates.get(itemKeyAtScope);
+                if (!itemState) {
                     throw new Error(`GroupByStep: item with key "${itemKeyAtScope}" not found when handling nested path addition notification`);
                 }
                 // Insert groupKey at the correct position
                 const modifiedKeyPath = [
                     ...notifiedKeyPath.slice(0, this.scopeSegments.length),
-                    groupKey,
+                    itemState.groupKey,
                     ...notifiedKeyPath.slice(this.scopeSegments.length)
                 ];
                 handler(modifiedKeyPath, itemKey, immutableProps);
@@ -216,13 +216,13 @@ export class GroupByStep<
             // Register interceptor with input at scope segments + shifted segments
             this.input.onRemoved([...this.scopeSegments, ...shiftedSegments], (notifiedKeyPath, itemKey, immutableProps) => {
                 const itemKeyAtScope = notifiedKeyPath[this.scopeSegments.length];
-                const groupKey = this.itemKeyToGroupKey.get(itemKeyAtScope);
-                if (groupKey === undefined) {
+                const itemState = this.itemStates.get(itemKeyAtScope);
+                if (!itemState) {
                     throw new Error(`GroupByStep: item with key "${itemKeyAtScope}" not found when handling nested path removal notification`);
                 }
                 const modifiedKeyPath = [
                     ...notifiedKeyPath.slice(0, this.scopeSegments.length),
-                    groupKey,
+                    itemState.groupKey,
                     ...notifiedKeyPath.slice(this.scopeSegments.length)
                 ];
                 handler(modifiedKeyPath, itemKey, immutableProps);
@@ -247,8 +247,8 @@ export class GroupByStep<
                     ? (notifiedKeyPath.length > 0 ? notifiedKeyPath[0] : itemKey)
                     : notifiedKeyPath[this.scopeSegments.length];
                     
-                const groupKey = this.itemKeyToGroupKey.get(itemKeyAtScope);
-                if (groupKey === undefined) {
+                const itemState = this.itemStates.get(itemKeyAtScope);
+                if (!itemState) {
                     // Item not yet tracked - this can happen during initial add when onModified
                     // fires before onAdded chain completes. Skip forwarding in this case.
                     // The event will be properly delivered once the item is added and tracked.
@@ -256,7 +256,7 @@ export class GroupByStep<
                 }
                 const modifiedKeyPath = [
                     ...notifiedKeyPath.slice(0, this.scopeSegments.length),
-                    groupKey,
+                    itemState.groupKey,
                     ...notifiedKeyPath.slice(this.scopeSegments.length)
                 ];
                 handler(modifiedKeyPath, itemKey, oldValue, newValue);
@@ -315,16 +315,13 @@ export class GroupByStep<
         // Find the item - key is the item key at the scope level
         const itemKey = keyPath.length > 0 ? keyPath[keyPath.length - 1] : key;
         
-        if (!this.itemKeyToGroupKey.has(itemKey)) {
+        const itemState = this.itemStates.get(itemKey);
+        if (!itemState) {
             return; // Item not tracked
         }
         
         // Get the current grouping values and update with new value
-        const currentGroupingValues = this.itemKeyToGroupingValues.get(itemKey);
-        if (!currentGroupingValues) {
-            return;
-        }
-        
+        const currentGroupingValues = itemState.groupingValues;
         const oldGroupingValues = { ...currentGroupingValues };
         const newGroupingValues = { ...currentGroupingValues, [propertyName]: newValue };
         
@@ -335,17 +332,17 @@ export class GroupByStep<
         // If the group key hasn't changed, no re-grouping needed
         if (oldGroupKey === newGroupKey) {
             // Just update the stored grouping values
-            this.itemKeyToGroupingValues.set(itemKey, newGroupingValues);
+            itemState.groupingValues = newGroupingValues;
             return;
         }
         
         // Re-group the item: remove from old group, add to new group
-        const parentKeyPath = this.itemKeyToParentKeyPath.get(itemKey) || [];
-        const oldCompositeKey = this.itemKeyToCompositeKey.get(itemKey)!;
+        const parentKeyPath = itemState.parentKeyPath;
+        const oldCompositeKey = itemState.compositeKey;
         const newCompositeKey = this.getCompositeGroupKey(parentKeyPath, newGroupKey);
         
         // Get the non-grouping properties for item handlers
-        const fullImmutableProps = this.itemKeyToImmutableProps.get(itemKey) || {};
+        const fullImmutableProps = itemState.immutableProps;
         const nonGroupingProps: ImmutableProps = {};
         Object.keys(fullImmutableProps).forEach(prop => {
             if (!this.groupingProperties.includes(prop as K)) {
@@ -377,9 +374,9 @@ export class GroupByStep<
         this.groupKeyToItemKeys.get(newCompositeKey)!.add(itemKey);
         
         // Update item's group mapping
-        this.itemKeyToGroupKey.set(itemKey, newGroupKey);
-        this.itemKeyToCompositeKey.set(itemKey, newCompositeKey);
-        this.itemKeyToGroupingValues.set(itemKey, newGroupingValues);
+        itemState.groupKey = newGroupKey;
+        itemState.compositeKey = newCompositeKey;
+        itemState.groupingValues = newGroupingValues;
         
         // Notify item handlers of the addition to new group
         this.itemAddedHandlers.forEach(handler => handler([...parentKeyPath, newGroupKey], itemKey, nonGroupingProps));
@@ -388,10 +385,6 @@ export class GroupByStep<
     private handleAdded(keyPath: string[], itemKey: string, immutableProps: ImmutableProps) {
         // keyPath is the runtime key path at the scope level - store it for emissions
         const parentKeyPath = keyPath;
-        this.itemKeyToParentKeyPath.set(itemKey, parentKeyPath);
-        
-        // Store full immutable props for potential re-grouping
-        this.itemKeyToImmutableProps.set(itemKey, immutableProps);
         
         // Extract the grouping property values from the object
         const groupingValues: ImmutableProps = {};
@@ -401,18 +394,19 @@ export class GroupByStep<
             }
         });
         
-        // Store grouping values for potential re-grouping
-        this.itemKeyToGroupingValues.set(itemKey, groupingValues);
-        
         // Compute the group key from the extracted values
         const groupKey = computeGroupKey(groupingValues, this.groupingProperties.map(prop => prop.toString()));
         
         // Create composite key that includes parent context for proper group tracking
         const compositeKey = this.getCompositeGroupKey(parentKeyPath, groupKey);
         
-        // Store item-to-group mapping
-        this.itemKeyToGroupKey.set(itemKey, groupKey);
-        this.itemKeyToCompositeKey.set(itemKey, compositeKey);
+        this.itemStates.set(itemKey, {
+            parentKeyPath,
+            groupKey,
+            compositeKey,
+            immutableProps,
+            groupingValues
+        });
         
         // Add item key to group's set - use composite key to track per-parent groups
         const isNewGroup = !this.groupKeyToItemKeys.has(compositeKey);
@@ -434,22 +428,20 @@ export class GroupByStep<
         this.itemAddedHandlers.forEach(handler => handler([...parentKeyPath, groupKey], itemKey, nonGroupingProps));
     }
 
-    private handleRemoved(keyPath: string[], itemKey: string, immutableProps: ImmutableProps) {
-        // Get the parent key path for this item key
-        const parentKeyPath = this.itemKeyToParentKeyPath.get(itemKey) || keyPath;
-        
-        // Look up group key and composite key
-        const groupKey = this.itemKeyToGroupKey.get(itemKey);
-        const compositeKey = this.itemKeyToCompositeKey.get(itemKey);
-        if (groupKey === undefined || compositeKey === undefined) {
+    private handleRemoved(keyPath: string[], itemKey: string, _immutableProps: ImmutableProps) {
+        const itemState = this.itemStates.get(itemKey);
+        if (!itemState) {
             throw new Error(`GroupByStep: item with key "${itemKey}" not found`);
         }
+        const parentKeyPath = itemState.parentKeyPath.length > 0 ? itemState.parentKeyPath : keyPath;
+        const groupKey = itemState.groupKey;
+        const compositeKey = itemState.compositeKey;
         
-        // Extract the non-grouping properties from the object for item handlers
+        // Extract the non-grouping properties from the tracked immutable props.
         const nonGroupingProps: ImmutableProps = {};
-        Object.keys(immutableProps).forEach(prop => {
+        Object.keys(itemState.immutableProps).forEach(prop => {
             if (!this.groupingProperties.includes(prop as K)) {
-                nonGroupingProps[prop] = immutableProps[prop];
+                nonGroupingProps[prop] = itemState.immutableProps[prop];
             }
         });
         
@@ -457,11 +449,7 @@ export class GroupByStep<
         this.itemRemovedHandlers.forEach(handler => handler([...parentKeyPath, groupKey], itemKey, nonGroupingProps));
         
         // Remove item key from tracking
-        this.itemKeyToGroupKey.delete(itemKey);
-        this.itemKeyToParentKeyPath.delete(itemKey);
-        this.itemKeyToCompositeKey.delete(itemKey);
-        this.itemKeyToImmutableProps.delete(itemKey);
-        this.itemKeyToGroupingValues.delete(itemKey);
+        this.itemStates.delete(itemKey);
         
         // Remove item key from group's set - use composite key for per-parent tracking
         const itemKeys = this.groupKeyToItemKeys.get(compositeKey);
@@ -470,16 +458,8 @@ export class GroupByStep<
             
             // Check if group is empty
             if (itemKeys.size === 0) {
-                // Extract the grouping property values from the object for group handlers
-                const groupingValues: ImmutableProps = {};
-                Object.keys(immutableProps).forEach(prop => {
-                    if (this.groupingProperties.includes(prop as K)) {
-                        groupingValues[prop] = immutableProps[prop];
-                    }
-                });
-                
                 // Notify group removed handlers at parent key path
-                this.groupRemovedHandlers.forEach(handler => handler(parentKeyPath, groupKey, groupingValues));
+                this.groupRemovedHandlers.forEach(handler => handler(parentKeyPath, groupKey, itemState.groupingValues));
                 
                 // Clean up tracking
                 this.groupKeyToItemKeys.delete(compositeKey);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove unsafe source wiring by changing `SourceBindableInput#setSources` to accept `PipelineSources<TSources>` and assigning directly in `InputStep`
- tighten `PipelineSources` fallback typing so `buildGraph().sources` remains assignable without double-casts
- remove `Record<string, any>` usage in runtime keyed-array mutation helpers by introducing typed dynamic access via `ImmutableProps`
- remove `PipelineBuilder.commutativeAggregate` type-erasure casts (`add as AddOperator<ImmutableProps,...>` / `subtract as ...`) and pass operators with their concrete item type
- replace repeated `[] as unknown as Path` resets with plain `[]` scope resets and use runtime `string[]` storage for `scopeSegments`
- reduce degrees of freedom in `GroupByStep` by consolidating per-item state maps into a single `itemStates` map
- reduce degrees of freedom in `AverageAggregateStep` by removing duplicated cached average state and deriving average from `sum/count`

## Validation
- `npm run typecheck`
- `npm run test -- --runInBand src/test/pipeline.group-by.test.ts src/test/pipeline.group-by-nested.test.ts src/test/pipeline.aggregate-functions.test.ts src/test/pipeline.in-prefix.test.ts src/test/pipeline.enrich.test.ts`
- `npm run build`
- `npm run test:types`

## Notes
- `EnrichStep` still intentionally keeps both full `secondaryState` and `secondaryRowByJoinKey` index. This remains a conscious state+index tradeoff for nested secondary updates and O(1) join lookups; no behavior change in this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f39fa08a-51b6-4f57-ba9d-a7d8a1fe8096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f39fa08a-51b6-4f57-ba9d-a7d8a1fe8096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

