### PR TITLE
Tighten pipeline typing and simplify step state

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -552,9 +552,20 @@ export class PipelineBuilder<
     constructor(
         private rootBuilder: StepBuilder,
         private lastBuilder: StepBuilder,
-        private scopeSegments: Path = [] as unknown as Path,
+        private scopeSegments: string[] = [],
         private diagnosticBridge: DeferredDiagnosticBridge = createDeferredDiagnosticBridge()
     ) {}
+
+    private rootScoped<TNext extends object, TNextRootScopeName extends string = RootScopeName, TNextSources extends Record<string, unknown> = TSources>(
+        nextBuilder: StepBuilder
+    ): PipelineBuilder<TNext, TStart, [], TNextRootScopeName, TNextSources> {
+        return new PipelineBuilder<TNext, TStart, [], TNextRootScopeName, TNextSources>(
+            this.rootBuilder,
+            nextBuilder,
+            [],
+            this.diagnosticBridge
+        );
+    }
 
     /**
      * Adds a computed property to each item at the current path.
@@ -576,7 +587,7 @@ export class PipelineBuilder<
             ? Expand<T & Record<K, U>>
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<K, U>>>,
         TStart,
-        Path,
+        [],
         RootScopeName,
         TSources
     > {
@@ -587,7 +598,7 @@ export class PipelineBuilder<
             this.scopeSegments as string[],
             mutableProperties
         );
-        return new PipelineBuilder(this.rootBuilder, newBuilder, [] as unknown as Path, this.diagnosticBridge);
+        return this.rootScoped(newBuilder);
     }
 
     dropProperty<K extends keyof NavigateToPath<T, Path>>(propertyName: K): PipelineBuilder<
@@ -595,7 +606,7 @@ export class PipelineBuilder<
             ? Expand<Omit<T, K>>
             : Expand<TransformAtPath<T, Path, Expand<Omit<NavigateToPath<T, Path>, K>>>>,
         TStart,
-        Path,
+        [],
         RootScopeName,
         TSources
     > {
@@ -604,7 +615,7 @@ export class PipelineBuilder<
             propertyName as string,
             this.scopeSegments as string[]
         );
-        return new PipelineBuilder(this.rootBuilder, newBuilder, [] as unknown as Path, this.diagnosticBridge);
+        return this.rootScoped(newBuilder);
     }
 
     groupBy<K extends keyof NavigateToPath<T, Path>, ArrayName extends string>(
@@ -615,7 +626,7 @@ export class PipelineBuilder<
             ? Expand<{ [P in K]: NavigateToPath<T, Path>[P] } & { [P in CurrentScopeName<Path, RootScopeName>]: KeyedArray<{ [Q in Exclude<keyof NavigateToPath<T, Path>, K>]: NavigateToPath<T, Path>[Q] }> }>
             : Expand<TransformAtPath<T, Path, { [P in K]: NavigateToPath<T, Path>[P] } & { [P in CurrentScopeName<Path, RootScopeName>]: KeyedArray<{ [Q in Exclude<keyof NavigateToPath<T, Path>, K>]: NavigateToPath<T, Path>[Q] }> }>>,
         TStart,
-        Path,
+        [],
         Path extends [] ? ArrayName : RootScopeName,
         TSources
     > {
@@ -631,7 +642,12 @@ export class PipelineBuilder<
             inferredChildArrayName,
             this.scopeSegments as string[]
         );
-        return new PipelineBuilder(this.rootBuilder, newBuilder, [] as unknown as Path, this.diagnosticBridge);
+        return this.rootScoped<
+            Path extends []
+                ? Expand<{ [P in K]: NavigateToPath<T, Path>[P] } & { [P in CurrentScopeName<Path, RootScopeName>]: KeyedArray<{ [Q in Exclude<keyof NavigateToPath<T, Path>, K>]: NavigateToPath<T, Path>[Q] }> }>
+                : Expand<TransformAtPath<T, Path, { [P in K]: NavigateToPath<T, Path>[P] } & { [P in CurrentScopeName<Path, RootScopeName>]: KeyedArray<{ [Q in Exclude<keyof NavigateToPath<T, Path>, K>]: NavigateToPath<T, Path>[Q] }> }>>,
+            Path extends [] ? ArrayName : RootScopeName
+        >(newBuilder);
     }
 
     flatten<
@@ -648,7 +664,7 @@ export class PipelineBuilder<
     ): PipelineBuilder<
         TransformWithFlatten<T, Path, ParentArrayName, OutputArrayName, FlattenedItem>,
         TStart,
-        Path,
+        [],
         RootScopeName,
         TSources
     > {
@@ -658,7 +674,7 @@ export class PipelineBuilder<
         const newBuilder = new FlattenBuilder(this.lastBuilder, parentPath, childPath, outputPath);
         // Preserve definition-time validation semantics for invalid flatten configurations.
         newBuilder.getTypeDescriptor();
-        return new PipelineBuilder(this.rootBuilder, newBuilder, [] as unknown as Path, this.diagnosticBridge);
+        return this.rootScoped(newBuilder);
     }
 
     /*
@@ -714,35 +730,36 @@ export class PipelineBuilder<
      */
     commutativeAggregate<
         ArrayName extends ArrayPropertyNameAtCurrentPath<T, Path>,
+        TItem extends ArrayItemAtCurrentPath<T, Path, ArrayName> & ImmutableProps,
         PropName extends string,
         TAggregate
     >(
         arrayName: ArrayName,
         propertyName: PropName,
-        add: AddOperator<ArrayItemAtCurrentPath<T, Path, ArrayName>, TAggregate>,
-        subtract: SubtractOperator<ArrayItemAtCurrentPath<T, Path, ArrayName>, TAggregate>,
+        add: AddOperator<TItem, TAggregate>,
+        subtract: SubtractOperator<TItem, TAggregate>,
         propertyToAggregate?: string
     ): PipelineBuilder<
         Path extends []
             ? TransformWithAggregate<T, [ArrayName], PropName, TAggregate>
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<PropName, TAggregate>>>,
         TStart,
-        Path,
+        [],
         RootScopeName,
         TSources
     > {
         const fullSegmentPath = [...this.scopeSegments, arrayName];
-        const newBuilder = new CommutativeAggregateBuilder(
+        const newBuilder = new CommutativeAggregateBuilder<TItem, TAggregate>(
             this.lastBuilder,
             fullSegmentPath,
             propertyName,
             {
-                add: add as AddOperator<ImmutableProps, TAggregate>,
-                subtract: subtract as SubtractOperator<ImmutableProps, TAggregate>
+                add,
+                subtract
             },
             propertyToAggregate
         );
-        return new PipelineBuilder(this.rootBuilder, newBuilder, [] as unknown as Path, this.diagnosticBridge);
+        return this.rootScoped(newBuilder);
     }
 
     cumulativeSum<
@@ -791,20 +808,20 @@ export class PipelineBuilder<
             ? TransformWithAggregate<T, [ArrayName], TPropName, number>
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TPropName, number>>>,
         TStart,
-        Path,
+        [],
         RootScopeName,
         TSources
     > {
         return this.commutativeAggregate(
             arrayName,
             outputProperty,
-            (acc: number | undefined, item: unknown) => {
-                const value = (item as Record<string, unknown>)[propertyName];
+            (acc: number | undefined, item: ArrayItemAtCurrentPath<T, Path, ArrayName>) => {
+                const value = item[propertyName];
                 const numValue = finiteNumericContribution(value);
                 return (acc ?? 0) + numValue;
             },
-            (acc: number, item: unknown) => {
-                const value = (item as Record<string, unknown>)[propertyName];
+            (acc: number, item: ArrayItemAtCurrentPath<T, Path, ArrayName>) => {
+                const value = item[propertyName];
                 const numValue = finiteNumericContribution(value);
                 return acc - numValue;
             },
@@ -834,15 +851,15 @@ export class PipelineBuilder<
             ? TransformWithAggregate<T, [ArrayName], TPropName, number>
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TPropName, number>>>,
         TStart,
-        Path,
+        [],
         RootScopeName,
         TSources
     > {
         return this.commutativeAggregate(
             arrayName,
             outputProperty,
-            (acc: number | undefined, _item: unknown) => (acc ?? 0) + 1,
-            (acc: number, _item: unknown) => acc - 1
+            (acc: number | undefined, _item: ArrayItemAtCurrentPath<T, Path, ArrayName>) => (acc ?? 0) + 1,
+            (acc: number, _item: ArrayItemAtCurrentPath<T, Path, ArrayName>) => acc - 1
         );
     }
     
@@ -870,7 +887,7 @@ export class PipelineBuilder<
             ? TransformWithAggregate<T, [ArrayName], TPropName, number | undefined>
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TPropName, number | undefined>>>,
         TStart,
-        Path,
+        [],
         RootScopeName,
         TSources
     > {
@@ -882,7 +899,7 @@ export class PipelineBuilder<
             propertyName,
             (left, right) => left - right
         );
-        return new PipelineBuilder(this.rootBuilder, newBuilder, [] as unknown as Path, this.diagnosticBridge);
+        return this.rootScoped(newBuilder);
     }
     
     /**
@@ -909,7 +926,7 @@ export class PipelineBuilder<
             ? TransformWithAggregate<T, [ArrayName], TPropName, number | undefined>
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TPropName, number | undefined>>>,
         TStart,
-        Path,
+        [],
         RootScopeName,
         TSources
     > {
@@ -921,7 +938,7 @@ export class PipelineBuilder<
             propertyName,
             (left, right) => right - left
         );
-        return new PipelineBuilder(this.rootBuilder, newBuilder, [] as unknown as Path, this.diagnosticBridge);
+        return this.rootScoped(newBuilder);
     }
 
     replaceToDelta<
@@ -951,7 +968,7 @@ export class PipelineBuilder<
                 >
             >,
         TStart,
-        Path,
+        [],
         RootScopeName,
         TSources
     > {
@@ -966,7 +983,7 @@ export class PipelineBuilder<
         );
         // Preserve definition-time validation semantics for invalid replaceToDelta configuration.
         newBuilder.getTypeDescriptor();
-        return new PipelineBuilder(this.rootBuilder, newBuilder, [] as unknown as Path, this.diagnosticBridge);
+        return this.rootScoped(newBuilder);
     }
     
     /**
@@ -993,7 +1010,7 @@ export class PipelineBuilder<
             ? TransformWithAggregate<T, [ArrayName], TPropName, number | undefined>
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TPropName, number | undefined>>>,
         TStart,
-        Path,
+        [],
         RootScopeName,
         TSources
     > {
@@ -1004,7 +1021,7 @@ export class PipelineBuilder<
             outputProperty,
             propertyName
         );
-        return new PipelineBuilder(this.rootBuilder, newBuilder, [] as unknown as Path, this.diagnosticBridge);
+        return this.rootScoped(newBuilder);
     }
     
     /**
@@ -1032,7 +1049,7 @@ export class PipelineBuilder<
             ? TransformWithAggregate<T, [ArrayName], TPropName, ArrayItemAtCurrentPath<T, Path, ArrayName> | undefined>
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TPropName, ArrayItemAtCurrentPath<T, Path, ArrayName> | undefined>>>,
         TStart,
-        Path,
+        [],
         RootScopeName,
         TSources
     > {
@@ -1044,7 +1061,7 @@ export class PipelineBuilder<
             propertyName,
             compareMixedPrimitiveValues
         );
-        return new PipelineBuilder(this.rootBuilder, newBuilder, [] as unknown as Path, this.diagnosticBridge);
+        return this.rootScoped(newBuilder);
     }
     
     /**
@@ -1072,7 +1089,7 @@ export class PipelineBuilder<
             ? TransformWithAggregate<T, [ArrayName], TPropName, ArrayItemAtCurrentPath<T, Path, ArrayName> | undefined>
             : Expand<TransformAtPath<T, Path, NavigateToPath<T, Path> & Record<TPropName, ArrayItemAtCurrentPath<T, Path, ArrayName> | undefined>>>,
         TStart,
-        Path,
+        [],
         RootScopeName,
         TSources
     > {
@@ -1084,7 +1101,7 @@ export class PipelineBuilder<
             propertyName,
             (left, right) => compareMixedPrimitiveValues(right, left)
         );
-        return new PipelineBuilder(this.rootBuilder, newBuilder, [] as unknown as Path, this.diagnosticBridge);
+        return this.rootScoped(newBuilder);
     }
     
     /**
@@ -1310,7 +1327,23 @@ function createKeyToIndexMap<T>(state: KeyedArray<T>): Map<string, number> {
     return keyToIndex;
 }
 
-function addToKeyedArray<T>(
+function getObjectRecord(value: object): Record<string, unknown> {
+    return value as Record<string, unknown>;
+}
+
+function getNestedKeyedArray(value: object, segment: string): KeyedArray<object> {
+    const nestedValue = getObjectRecord(value)[segment];
+    return Array.isArray(nestedValue) ? nestedValue as KeyedArray<object> : [];
+}
+
+function withUpdatedProperty<T extends object>(value: T, propertyName: string, propertyValue: unknown): T {
+    return {
+        ...getObjectRecord(value),
+        [propertyName]: propertyValue
+    } as T;
+}
+
+function addToKeyedArray<T extends object>(
     state: KeyedArray<T>,
     segmentPath: string[],
     keyPath: string[],
@@ -1351,10 +1384,8 @@ function addToKeyedArray<T>(
             return state;
         }
         const existingItem = state[existingItemIndex];
-        // Dynamic property access: segment is used as a property key at runtime
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Runtime hierarchical structure manipulation
-        const value = existingItem.value as Record<string, any>;
-        const existingArray = (value[segment] as KeyedArray<unknown>) || [];
+        const existingValue = existingItem.value;
+        const existingArray = getNestedKeyedArray(existingValue, segment);
         const modifiedArray = addToKeyedArray(
             existingArray,
             segmentPath.slice(1),
@@ -1366,10 +1397,7 @@ function addToKeyedArray<T>(
         );
         const modifiedItem = {
             key: parentKey,
-            value: {
-                ...value,
-                [segmentPath[0]]: modifiedArray
-            } as T
+            value: withUpdatedProperty(existingValue, segment, modifiedArray)
         };
         return [
             ...state.slice(0, existingItemIndex),
@@ -1379,7 +1407,7 @@ function addToKeyedArray<T>(
     }
 }
 
-function removeFromKeyedArray<T>(
+function removeFromKeyedArray<T extends object>(
     state: KeyedArray<T>,
     segmentPath: string[],
     keyPath: string[],
@@ -1419,10 +1447,8 @@ function removeFromKeyedArray<T>(
             return state;
         }
         const existingItem = state[existingItemIndex];
-        // Dynamic property access: segment is used as a property key at runtime
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Runtime hierarchical structure manipulation
-        const value = existingItem.value as Record<string, any>;
-        const existingArray = (value[segment] as KeyedArray<unknown>) || [];
+        const existingValue = existingItem.value;
+        const existingArray = getNestedKeyedArray(existingValue, segment);
         const modifiedArray = removeFromKeyedArray(
             existingArray,
             segmentPath.slice(1),
@@ -1433,10 +1459,7 @@ function removeFromKeyedArray<T>(
         );
         const modifiedItem = {
             key: parentKey,
-            value: {
-                ...value,
-                [segmentPath[0]]: modifiedArray
-            } as T
+            value: withUpdatedProperty(existingValue, segment, modifiedArray)
         };
         return [
             ...state.slice(0, existingItemIndex),
@@ -1446,7 +1469,7 @@ function removeFromKeyedArray<T>(
     }
 }
 
-function modifyInKeyedArray<T>(
+function modifyInKeyedArray<T extends object>(
     state: KeyedArray<T>,
     segmentPath: string[],
     keyPath: string[],
@@ -1479,14 +1502,10 @@ function modifyInKeyedArray<T>(
             return state;
         }
         const existingItem = state[existingItemIndex];
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Runtime hierarchical structure manipulation
-        const existingValue = existingItem.value as Record<string, any>;
+        const existingValue = existingItem.value;
         const modifiedItem = {
             key: key,
-            value: {
-                ...existingValue,
-                [name]: value
-            } as T
+            value: withUpdatedProperty(existingValue, name, value)
         };
         return [
             ...state.slice(0, existingItemIndex),
@@ -1520,10 +1539,8 @@ function modifyInKeyedArray<T>(
             return state;
         }
         const existingItem = state[existingItemIndex];
-        // Dynamic property access: segment is used as a property key at runtime
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Runtime hierarchical structure manipulation
-        const existingValue = existingItem.value as Record<string, any>;
-        const existingArray = (existingValue[segment] as KeyedArray<unknown>) || [];
+        const existingValue = existingItem.value;
+        const existingArray = getNestedKeyedArray(existingValue, segment);
         const modifiedArray = modifyInKeyedArray(
             existingArray,
             segmentPath.slice(1),
@@ -1536,10 +1553,7 @@ function modifyInKeyedArray<T>(
         );
         const modifiedItem = {
             key: parentKey,
-            value: {
-                ...existingValue,
-                [segmentPath[0]]: modifiedArray
-            } as T
+            value: withUpdatedProperty(existingValue, segment, modifiedArray)
         };
         return [
             ...state.slice(0, existingItemIndex),

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -10,10 +10,21 @@ import type {
     SourceBindableInput,
     Step,
     StepBuilder,
-    TypeDescriptor
+    TypeDescriptor,
+    UntypedPipelineSources
 } from './pipeline.js';
 
 type EmptySources = Record<never, never>;
+
+function createEmptySources<TSources extends Record<string, unknown>>(): PipelineSources<TSources> {
+    return {} as PipelineSources<TSources>;
+}
+
+function bindSources<TSources extends Record<string, unknown>>(
+    sources: UntypedPipelineSources
+): PipelineSources<TSources> {
+    return sources as PipelineSources<TSources>;
+}
 
 // Kept in factory for createPipeline initialization.
 export class InputStep<T, TSources extends Record<string, unknown> = EmptySources>
@@ -21,11 +32,7 @@ export class InputStep<T, TSources extends Record<string, unknown> = EmptySource
     private addedHandlers: AddedHandler[] = [];
     private removedHandlers: RemovedHandler[] = [];
 
-    sources: PipelineSources<TSources>;
-
-    constructor() {
-        this.sources = {} as PipelineSources<TSources>;
-    }
+    sources: PipelineSources<TSources> = createEmptySources<TSources>();
 
     add(key: string, immutableProps: T): void {
         this.addedHandlers.forEach(handler => handler([], key, immutableProps as ImmutableProps));
@@ -55,8 +62,8 @@ export class InputStep<T, TSources extends Record<string, unknown> = EmptySource
         // No modifications at the input step.
     }
 
-    setSources(sources: Record<string, SourceBindableInput<unknown, Record<string, unknown>>>): void {
-        this.sources = sources as unknown as PipelineSources<TSources>;
+    setSources(sources: UntypedPipelineSources): void {
+        this.sources = bindSources<TSources>(sources);
     }
 }
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -10,6 +10,15 @@ export type PipelineSources<TSources extends Record<string, unknown>> = {
             : never;
 };
 
+type UntypedSourceGraphShape = {
+    [sourceName: string]: {
+        primary: unknown;
+        sources?: UntypedSourceGraphShape;
+    };
+};
+
+export type UntypedPipelineSources = PipelineSources<UntypedSourceGraphShape>;
+
 export interface PipelineInput<T, TSources extends Record<string, unknown> = EmptySources> {
     add(key: string, immutableProps: T): void;
     remove(key: string, immutableProps: T): void;
@@ -18,7 +27,7 @@ export interface PipelineInput<T, TSources extends Record<string, unknown> = Emp
 
 export interface SourceBindableInput<T, TSources extends Record<string, unknown> = EmptySources>
     extends PipelineInput<T, TSources> {
-    setSources(sources: Record<string, SourceBindableInput<unknown, Record<string, unknown>>>): void;
+    setSources(sources: UntypedPipelineSources): void;
 }
 
 export interface PipelineRuntimeDiagnostic {
@@ -176,7 +185,7 @@ export interface Step {
 export interface BuiltStepGraph {
     rootInput: SourceBindableInput<unknown, Record<string, unknown>>;
     lastStep: Step;
-    sources: Record<string, SourceBindableInput<unknown, Record<string, unknown>>>;
+    sources: UntypedPipelineSources;
 }
 
 export interface BuildContext {

--- a/src/steps/average-aggregate.ts
+++ b/src/steps/average-aggregate.ts
@@ -38,7 +38,6 @@ function transformAverageAggregateDescriptor(
 interface AverageState {
     sum: number;
     count: number;
-    average: number | undefined;
 }
 
 /**
@@ -63,9 +62,6 @@ export class AverageAggregateStep<
         propertyName: string;
         handler: ModifiedHandler;
     }> = [];
-    
-    /** Maps parent key path hash to current average value (for oldValue tracking) */
-    private aggregateValues: Map<string, number | undefined> = new Map();
     
     /** Whether the property being aggregated is mutable (auto-detected) */
     private isPropertyMutable: boolean = false;
@@ -138,6 +134,11 @@ export class AverageAggregateStep<
         
         return pathSegments.every((segment, i) => segment === parentSegments[i]);
     }
+
+    private getAverageForParent(parentKeyHash: string): number | undefined {
+        const state = this.averageStates.get(parentKeyHash);
+        return state && state.count > 0 ? state.sum / state.count : undefined;
+    }
     
     /**
      * Handle when an item is added to the target array
@@ -146,6 +147,8 @@ export class AverageAggregateStep<
         const parentKeyPath = keyPath;
         const parentKeyHash = computeKeyPathHash(parentKeyPath);
         
+        const oldAverage = this.getAverageForParent(parentKeyHash);
+
         // Initialize itemValues map for this parent if needed
         if (!this.itemValues.has(parentKeyHash)) {
             this.itemValues.set(parentKeyHash, new Map());
@@ -168,19 +171,15 @@ export class AverageAggregateStep<
                 this.itemValues.get(parentKeyHash)!.set(itemKey, numValue);
                 
                 // Update sum and count
-                const state = this.averageStates.get(parentKeyHash) || { sum: 0, count: 0, average: undefined };
+                const state = this.averageStates.get(parentKeyHash) || { sum: 0, count: 0 };
                 state.sum += numValue;
                 state.count += 1;
-                state.average = state.sum / state.count;
                 this.averageStates.set(parentKeyHash, state);
             }
         }
         
         // Compute new average
-        const state = this.averageStates.get(parentKeyHash);
-        const oldAverage = this.aggregateValues.get(parentKeyHash);
-        const newAverage = (state && state.count > 0) ? state.average : undefined;
-        this.aggregateValues.set(parentKeyHash, newAverage);
+        const newAverage = this.getAverageForParent(parentKeyHash);
         
         // Emit modification event
         if (parentKeyPath.length > 0) {
@@ -229,11 +228,11 @@ export class AverageAggregateStep<
         // Get or create state
         let state = this.averageStates.get(parentKeyHash);
         if (!state) {
-            state = { sum: 0, count: 0, average: undefined };
+            state = { sum: 0, count: 0 };
             this.averageStates.set(parentKeyHash, state);
         }
         
-        const oldAverage = state.average;
+        const oldAverage = this.getAverageForParent(parentKeyHash);
         
         // Update sum and count based on what changed
         if (hadOldValue && hasNewValue) {
@@ -250,20 +249,11 @@ export class AverageAggregateStep<
         }
         
         // Calculate new average
-        if (state.count > 0) {
-            state.average = state.sum / state.count;
-        } else {
-            state.average = undefined;
+        if (state.count <= 0) {
             this.averageStates.delete(parentKeyHash);
         }
         
-        // Update aggregate values cache
-        const newAverage = state.average;
-        if (newAverage !== undefined) {
-            this.aggregateValues.set(parentKeyHash, newAverage);
-        } else {
-            this.aggregateValues.delete(parentKeyHash);
-        }
+        const newAverage = this.getAverageForParent(parentKeyHash);
         
         // Emit modification event
         if (parentKeyPath.length > 0) {
@@ -287,6 +277,8 @@ export class AverageAggregateStep<
         const parentKeyPath = keyPath;
         const parentKeyHash = computeKeyPathHash(parentKeyPath);
         
+        const oldAverage = this.getAverageForParent(parentKeyHash);
+
         // Get the value to remove - either from itemValues map (for mutable) or from item (for immutable)
         let valueToRemove: number | undefined;
         
@@ -319,25 +311,15 @@ export class AverageAggregateStep<
                 state.count -= 1;
                 
                 if (state.count === 0) {
-                    state.average = undefined;
                     this.averageStates.delete(parentKeyHash);
                 } else {
-                    state.average = state.sum / state.count;
                     this.averageStates.set(parentKeyHash, state);
                 }
             }
         }
         
         // Compute new average
-        const state = this.averageStates.get(parentKeyHash);
-        const oldAverage = this.aggregateValues.get(parentKeyHash);
-        const newAverage = (state && state.count > 0) ? state.average : undefined;
-        
-        if (!state || state.count === 0) {
-            this.aggregateValues.delete(parentKeyHash);
-        } else {
-            this.aggregateValues.set(parentKeyHash, newAverage);
-        }
+        const newAverage = this.getAverageForParent(parentKeyHash);
         
         // Emit modification event
         if (parentKeyPath.length > 0) {

--- a/src/steps/commutative-aggregate.ts
+++ b/src/steps/commutative-aggregate.ts
@@ -108,6 +108,12 @@ export class CommutativeAggregateStep<
     
     /** Whether the property being aggregated is mutable (auto-detected) */
     private isPropertyMutable: boolean = false;
+
+    /**
+     * Tracks full item snapshots by parent path so mutable-property updates can
+     * reapply operators with the real TItem shape rather than a partial record.
+     */
+    private itemSnapshots: Map<string, Map<string, TItem>> = new Map();
     
     constructor(
         private input: Step,
@@ -188,16 +194,28 @@ export class CommutativeAggregateStep<
     private asAggregateItem(item: ImmutableProps): TItem {
         return item as TItem;
     }
+
+    private getItemSnapshotsForParent(parentKeyHash: string): Map<string, TItem> {
+        const existingSnapshots = this.itemSnapshots.get(parentKeyHash);
+        if (existingSnapshots) {
+            return existingSnapshots;
+        }
+        const snapshots = new Map<string, TItem>();
+        this.itemSnapshots.set(parentKeyHash, snapshots);
+        return snapshots;
+    }
     
     /**
      * Handle when an item is added to the target array
      */
-    private handleItemAdded(keyPath: string[], _itemKey: string, item: ImmutableProps): void {
+    private handleItemAdded(keyPath: string[], itemKey: string, item: ImmutableProps): void {
         // keyPath contains the runtime keys leading to this item
         // For segmentPath ['cities', 'venues'], keyPath might be ['hash_TX', 'hash_Dallas']
         
         const parentKeyPath = keyPath;
         const parentKeyHash = computeKeyPathHash(parentKeyPath);
+        const itemSnapshots = this.getItemSnapshotsForParent(parentKeyHash);
+        itemSnapshots.set(itemKey, this.asAggregateItem(item));
         
         // Track item count for cleanup
         const currentCount = this.itemCounts.get(parentKeyHash) ?? 0;
@@ -247,9 +265,21 @@ export class CommutativeAggregateStep<
     /**
      * Handle when a mutable property of an aggregated item changes
      */
-    private handleItemPropertyChanged(keyPath: string[], _itemKey: string, propertyName: string, oldValue: unknown, newValue: unknown): void {
+    private handleItemPropertyChanged(keyPath: string[], itemKey: string, propertyName: string, oldValue: unknown, newValue: unknown): void {
         const parentKeyPath = keyPath;
         const parentKeyHash = computeKeyPathHash(parentKeyPath);
+        const itemSnapshots = this.getItemSnapshotsForParent(parentKeyHash);
+        const existingSnapshot = itemSnapshots.get(itemKey);
+
+        if (!existingSnapshot) {
+            return;
+        }
+
+        const updatedSnapshot = this.asAggregateItem({
+            ...existingSnapshot,
+            [propertyName]: newValue
+        });
+        itemSnapshots.set(itemKey, updatedSnapshot);
         
         // Get the current aggregate
         const currentAggregate = this.aggregateValues.get(parentKeyHash);
@@ -257,9 +287,8 @@ export class CommutativeAggregateStep<
         // Handle the case where this is the first value for a mutable property
         // (oldValue is undefined, no aggregate yet)
         if (currentAggregate === undefined && oldValue === undefined) {
-            // This is the initial value for the property - treat as a fresh add
-            const newItem = { [propertyName]: newValue } as TItem;
-            const newAggregate = this.config.add(undefined, newItem);
+            // This is the initial value for the property - treat as a fresh add.
+            const newAggregate = this.config.add(undefined, updatedSnapshot);
             this.aggregateValues.set(parentKeyHash, newAggregate);
             
             // Emit modification event
@@ -283,20 +312,14 @@ export class CommutativeAggregateStep<
             return;
         }
         
-        // For commutative aggregates, we can update incrementally:
-        // newAggregate = currentAggregate - oldContribution + newContribution
-        //
-        // The config.add and config.subtract operators expect items with properties,
-        // so we create pseudo-items with just the changed property.
-        // This works because sum/count operators extract item[propertyName].
-        
-        // Create pseudo-items with the old and new values
-        const oldItem = { [propertyName]: oldValue } as TItem;
-        const newItem = { [propertyName]: newValue } as TItem;
+        const previousSnapshot = this.asAggregateItem({
+            ...updatedSnapshot,
+            [propertyName]: oldValue
+        });
         
         // Compute new aggregate: subtract old value, add new value
-        const intermediateAggregate = this.config.subtract(currentAggregate, oldItem);
-        const newAggregate = this.config.add(intermediateAggregate, newItem);
+        const intermediateAggregate = this.config.subtract(currentAggregate, previousSnapshot);
+        const newAggregate = this.config.add(intermediateAggregate, updatedSnapshot);
         
         // Update stored aggregate
         this.aggregateValues.set(parentKeyHash, newAggregate);
@@ -320,9 +343,10 @@ export class CommutativeAggregateStep<
     /**
      * Handle when an item is removed from the target array
      */
-    private handleItemRemoved(keyPath: string[], _itemKey: string, item: ImmutableProps): void {
+    private handleItemRemoved(keyPath: string[], itemKey: string, item: ImmutableProps): void {
         const parentKeyPath = keyPath;
         const parentKeyHash = computeKeyPathHash(parentKeyPath);
+        const itemSnapshots = this.itemSnapshots.get(parentKeyHash);
         
         // Get current aggregate
         const currentAggregate = this.aggregateValues.get(parentKeyHash);
@@ -331,7 +355,8 @@ export class CommutativeAggregateStep<
         }
         
         // Compute new aggregate
-        const newAggregate = this.config.subtract(currentAggregate, this.asAggregateItem(item));
+        const removedItem = itemSnapshots?.get(itemKey) ?? this.asAggregateItem(item);
+        const newAggregate = this.config.subtract(currentAggregate, removedItem);
         
         // Update item count and clean up if no items remain
         const currentCount = this.itemCounts.get(parentKeyHash) ?? 0;
@@ -343,6 +368,14 @@ export class CommutativeAggregateStep<
         } else {
             this.itemCounts.delete(parentKeyHash);
             this.aggregateValues.delete(parentKeyHash);
+            this.itemSnapshots.delete(parentKeyHash);
+        }
+
+        if (itemSnapshots) {
+            itemSnapshots.delete(itemKey);
+            if (itemSnapshots.size === 0) {
+                this.itemSnapshots.delete(parentKeyHash);
+            }
         }
         
         // Emit modification event

--- a/src/steps/commutative-aggregate.ts
+++ b/src/steps/commutative-aggregate.ts
@@ -87,7 +87,7 @@ function transformCommutativeAggregateDescriptor(
  * @template TAggregate - The type of the aggregate value
  */
 export class CommutativeAggregateStep<
-    _TInput,
+    TItem extends ImmutableProps,
     TPath extends string[],
     TPropertyName extends string,
     TAggregate
@@ -113,7 +113,7 @@ export class CommutativeAggregateStep<
         private input: Step,
         private segmentPath: TPath,
         private propertyName: TPropertyName,
-        private config: CommutativeAggregateConfig<ImmutableProps, TAggregate>,
+        private config: CommutativeAggregateConfig<TItem, TAggregate>,
         private propertyToAggregate: string | undefined,
         inputDescriptor?: TypeDescriptor
     ) {
@@ -184,6 +184,10 @@ export class CommutativeAggregateStep<
         
         return pathSegments.every((segment, i) => segment === parentSegments[i]);
     }
+
+    private asAggregateItem(item: ImmutableProps): TItem {
+        return item as TItem;
+    }
     
     /**
      * Handle when an item is added to the target array
@@ -216,7 +220,7 @@ export class CommutativeAggregateStep<
         
         // Compute new aggregate
         const currentAggregate = this.aggregateValues.get(parentKeyHash);
-        const newAggregate = this.config.add(currentAggregate, item);
+        const newAggregate = this.config.add(currentAggregate, this.asAggregateItem(item));
         this.aggregateValues.set(parentKeyHash, newAggregate);
         
         // Emit modification event
@@ -254,7 +258,7 @@ export class CommutativeAggregateStep<
         // (oldValue is undefined, no aggregate yet)
         if (currentAggregate === undefined && oldValue === undefined) {
             // This is the initial value for the property - treat as a fresh add
-            const newItem = { [propertyName]: newValue } as ImmutableProps;
+            const newItem = { [propertyName]: newValue } as TItem;
             const newAggregate = this.config.add(undefined, newItem);
             this.aggregateValues.set(parentKeyHash, newAggregate);
             
@@ -287,8 +291,8 @@ export class CommutativeAggregateStep<
         // This works because sum/count operators extract item[propertyName].
         
         // Create pseudo-items with the old and new values
-        const oldItem = { [propertyName]: oldValue } as ImmutableProps;
-        const newItem = { [propertyName]: newValue } as ImmutableProps;
+        const oldItem = { [propertyName]: oldValue } as TItem;
+        const newItem = { [propertyName]: newValue } as TItem;
         
         // Compute new aggregate: subtract old value, add new value
         const intermediateAggregate = this.config.subtract(currentAggregate, oldItem);
@@ -327,7 +331,7 @@ export class CommutativeAggregateStep<
         }
         
         // Compute new aggregate
-        const newAggregate = this.config.subtract(currentAggregate, item);
+        const newAggregate = this.config.subtract(currentAggregate, this.asAggregateItem(item));
         
         // Update item count and clean up if no items remain
         const currentCount = this.itemCounts.get(parentKeyHash) ?? 0;
@@ -357,14 +361,14 @@ export class CommutativeAggregateStep<
     }
 }
 
-export class CommutativeAggregateBuilder<TAggregate> implements StepBuilder {
+export class CommutativeAggregateBuilder<TItem extends ImmutableProps, TAggregate> implements StepBuilder {
     constructor(
         readonly upstream: StepBuilder,
         private segmentPath: string[],
         private propertyName: string,
         private config: {
-            add: AddOperator<ImmutableProps, TAggregate>;
-            subtract: SubtractOperator<ImmutableProps, TAggregate>;
+            add: AddOperator<TItem, TAggregate>;
+            subtract: SubtractOperator<TItem, TAggregate>;
         },
         private propertyToAggregate?: string
     ) {

--- a/src/steps/group-by.ts
+++ b/src/steps/group-by.ts
@@ -120,19 +120,21 @@ export class GroupByStep<
     groupRemovedHandlers: RemovedHandler[] = [];
     itemRemovedHandlers: RemovedHandler[] = [];
 
-    itemKeyToGroupKey: Map<string, string> = new Map<string, string>();
+    private trackedItems: Map<string, {
+        parentKeyPath: string[];
+        groupKey: string;
+        compositeKey: string;
+        immutableProps: ImmutableProps;
+        groupingValues: ImmutableProps;
+    }> = new Map<string, {
+        parentKeyPath: string[];
+        groupKey: string;
+        compositeKey: string;
+        immutableProps: ImmutableProps;
+        groupingValues: ImmutableProps;
+    }>();
     // Maps composite key (parent path + group key) to item keys - tracks groups per parent context
     groupKeyToItemKeys: Map<string, Set<string>> = new Map<string, Set<string>>();
-    
-    // Maps item key to its parent key path for correct emission
-    itemKeyToParentKeyPath: Map<string, string[]> = new Map<string, string[]>();
-    // Maps item key to its composite key for removal
-    itemKeyToCompositeKey: Map<string, string> = new Map<string, string>();
-    
-    // Maps item key to its full immutable props (for re-grouping)
-    itemKeyToImmutableProps: Map<string, ImmutableProps> = new Map<string, ImmutableProps>();
-    // Maps item key to its current grouping values (for re-grouping)
-    itemKeyToGroupingValues: Map<string, ImmutableProps> = new Map<string, ImmutableProps>();
 
     private readonly childArrayName: ChildArrayName;
     constructor(
@@ -184,14 +186,14 @@ export class GroupByStep<
             this.input.onAdded([...this.scopeSegments, ...shiftedSegments], (notifiedKeyPath, itemKey, immutableProps) => {
                 // notifiedKeyPath is relative to scopeSegments, element at scopeSegments.length is the item key
                 const itemKeyAtScope = notifiedKeyPath[this.scopeSegments.length];
-                const groupKey = this.itemKeyToGroupKey.get(itemKeyAtScope);
-                if (groupKey === undefined) {
+                const trackedItem = this.trackedItems.get(itemKeyAtScope);
+                if (!trackedItem) {
                     throw new Error(`GroupByStep: item with key "${itemKeyAtScope}" not found when handling nested path addition notification`);
                 }
                 // Insert groupKey at the correct position
                 const modifiedKeyPath = [
                     ...notifiedKeyPath.slice(0, this.scopeSegments.length),
-                    groupKey,
+                    trackedItem.groupKey,
                     ...notifiedKeyPath.slice(this.scopeSegments.length)
                 ];
                 handler(modifiedKeyPath, itemKey, immutableProps);
@@ -216,13 +218,13 @@ export class GroupByStep<
             // Register interceptor with input at scope segments + shifted segments
             this.input.onRemoved([...this.scopeSegments, ...shiftedSegments], (notifiedKeyPath, itemKey, immutableProps) => {
                 const itemKeyAtScope = notifiedKeyPath[this.scopeSegments.length];
-                const groupKey = this.itemKeyToGroupKey.get(itemKeyAtScope);
-                if (groupKey === undefined) {
+                const trackedItem = this.trackedItems.get(itemKeyAtScope);
+                if (!trackedItem) {
                     throw new Error(`GroupByStep: item with key "${itemKeyAtScope}" not found when handling nested path removal notification`);
                 }
                 const modifiedKeyPath = [
                     ...notifiedKeyPath.slice(0, this.scopeSegments.length),
-                    groupKey,
+                    trackedItem.groupKey,
                     ...notifiedKeyPath.slice(this.scopeSegments.length)
                 ];
                 handler(modifiedKeyPath, itemKey, immutableProps);
@@ -246,9 +248,9 @@ export class GroupByStep<
                 const itemKeyAtScope = this.scopeSegments.length === 0
                     ? (notifiedKeyPath.length > 0 ? notifiedKeyPath[0] : itemKey)
                     : notifiedKeyPath[this.scopeSegments.length];
-                    
-                const groupKey = this.itemKeyToGroupKey.get(itemKeyAtScope);
-                if (groupKey === undefined) {
+
+                const trackedItem = this.trackedItems.get(itemKeyAtScope);
+                if (!trackedItem) {
                     // Item not yet tracked - this can happen during initial add when onModified
                     // fires before onAdded chain completes. Skip forwarding in this case.
                     // The event will be properly delivered once the item is added and tracked.
@@ -256,7 +258,7 @@ export class GroupByStep<
                 }
                 const modifiedKeyPath = [
                     ...notifiedKeyPath.slice(0, this.scopeSegments.length),
-                    groupKey,
+                    trackedItem.groupKey,
                     ...notifiedKeyPath.slice(this.scopeSegments.length)
                 ];
                 handler(modifiedKeyPath, itemKey, oldValue, newValue);
@@ -314,19 +316,14 @@ export class GroupByStep<
     private handleGroupingPropertyChange(keyPath: string[], key: string, propertyName: string, _oldValue: unknown, newValue: unknown): void {
         // Find the item - key is the item key at the scope level
         const itemKey = keyPath.length > 0 ? keyPath[keyPath.length - 1] : key;
-        
-        if (!this.itemKeyToGroupKey.has(itemKey)) {
+
+        const trackedItem = this.trackedItems.get(itemKey);
+        if (!trackedItem) {
             return; // Item not tracked
         }
-        
-        // Get the current grouping values and update with new value
-        const currentGroupingValues = this.itemKeyToGroupingValues.get(itemKey);
-        if (!currentGroupingValues) {
-            return;
-        }
-        
-        const oldGroupingValues = { ...currentGroupingValues };
-        const newGroupingValues = { ...currentGroupingValues, [propertyName]: newValue };
+
+        const oldGroupingValues = { ...trackedItem.groupingValues };
+        const newGroupingValues = { ...trackedItem.groupingValues, [propertyName]: newValue };
         
         // Compute old and new group keys
         const oldGroupKey = computeGroupKey(oldGroupingValues, this.groupingProperties.map(prop => prop.toString()));
@@ -334,18 +331,17 @@ export class GroupByStep<
         
         // If the group key hasn't changed, no re-grouping needed
         if (oldGroupKey === newGroupKey) {
-            // Just update the stored grouping values
-            this.itemKeyToGroupingValues.set(itemKey, newGroupingValues);
+            trackedItem.groupingValues = newGroupingValues;
+            trackedItem.immutableProps = { ...trackedItem.immutableProps, [propertyName]: newValue };
             return;
         }
-        
+
         // Re-group the item: remove from old group, add to new group
-        const parentKeyPath = this.itemKeyToParentKeyPath.get(itemKey) || [];
-        const oldCompositeKey = this.itemKeyToCompositeKey.get(itemKey)!;
+        const { parentKeyPath, compositeKey: oldCompositeKey } = trackedItem;
         const newCompositeKey = this.getCompositeGroupKey(parentKeyPath, newGroupKey);
-        
+
         // Get the non-grouping properties for item handlers
-        const fullImmutableProps = this.itemKeyToImmutableProps.get(itemKey) || {};
+        const fullImmutableProps = { ...trackedItem.immutableProps, [propertyName]: newValue };
         const nonGroupingProps: ImmutableProps = {};
         Object.keys(fullImmutableProps).forEach(prop => {
             if (!this.groupingProperties.includes(prop as K)) {
@@ -375,11 +371,11 @@ export class GroupByStep<
             this.groupAddedHandlers.forEach(handler => handler(parentKeyPath, newGroupKey, newGroupingValues));
         }
         this.groupKeyToItemKeys.get(newCompositeKey)!.add(itemKey);
-        
-        // Update item's group mapping
-        this.itemKeyToGroupKey.set(itemKey, newGroupKey);
-        this.itemKeyToCompositeKey.set(itemKey, newCompositeKey);
-        this.itemKeyToGroupingValues.set(itemKey, newGroupingValues);
+
+        trackedItem.groupKey = newGroupKey;
+        trackedItem.compositeKey = newCompositeKey;
+        trackedItem.groupingValues = newGroupingValues;
+        trackedItem.immutableProps = fullImmutableProps;
         
         // Notify item handlers of the addition to new group
         this.itemAddedHandlers.forEach(handler => handler([...parentKeyPath, newGroupKey], itemKey, nonGroupingProps));
@@ -388,11 +384,7 @@ export class GroupByStep<
     private handleAdded(keyPath: string[], itemKey: string, immutableProps: ImmutableProps) {
         // keyPath is the runtime key path at the scope level - store it for emissions
         const parentKeyPath = keyPath;
-        this.itemKeyToParentKeyPath.set(itemKey, parentKeyPath);
-        
-        // Store full immutable props for potential re-grouping
-        this.itemKeyToImmutableProps.set(itemKey, immutableProps);
-        
+
         // Extract the grouping property values from the object
         const groupingValues: ImmutableProps = {};
         Object.keys(immutableProps).forEach(prop => {
@@ -400,19 +392,20 @@ export class GroupByStep<
                 groupingValues[prop] = immutableProps[prop];
             }
         });
-        
-        // Store grouping values for potential re-grouping
-        this.itemKeyToGroupingValues.set(itemKey, groupingValues);
-        
+
         // Compute the group key from the extracted values
         const groupKey = computeGroupKey(groupingValues, this.groupingProperties.map(prop => prop.toString()));
-        
+
         // Create composite key that includes parent context for proper group tracking
         const compositeKey = this.getCompositeGroupKey(parentKeyPath, groupKey);
-        
-        // Store item-to-group mapping
-        this.itemKeyToGroupKey.set(itemKey, groupKey);
-        this.itemKeyToCompositeKey.set(itemKey, compositeKey);
+
+        this.trackedItems.set(itemKey, {
+            parentKeyPath,
+            groupKey,
+            compositeKey,
+            immutableProps,
+            groupingValues
+        });
         
         // Add item key to group's set - use composite key to track per-parent groups
         const isNewGroup = !this.groupKeyToItemKeys.has(compositeKey);
@@ -434,34 +427,28 @@ export class GroupByStep<
         this.itemAddedHandlers.forEach(handler => handler([...parentKeyPath, groupKey], itemKey, nonGroupingProps));
     }
 
-    private handleRemoved(keyPath: string[], itemKey: string, immutableProps: ImmutableProps) {
-        // Get the parent key path for this item key
-        const parentKeyPath = this.itemKeyToParentKeyPath.get(itemKey) || keyPath;
-        
-        // Look up group key and composite key
-        const groupKey = this.itemKeyToGroupKey.get(itemKey);
-        const compositeKey = this.itemKeyToCompositeKey.get(itemKey);
-        if (groupKey === undefined || compositeKey === undefined) {
+    private handleRemoved(keyPath: string[], itemKey: string, _immutableProps: ImmutableProps) {
+        const trackedItem = this.trackedItems.get(itemKey);
+        if (!trackedItem) {
             throw new Error(`GroupByStep: item with key "${itemKey}" not found`);
         }
-        
+        const parentKeyPath = trackedItem.parentKeyPath.length > 0 ? trackedItem.parentKeyPath : keyPath;
+        const { groupKey, compositeKey } = trackedItem;
+
+        const currentImmutableProps = trackedItem.immutableProps;
+
         // Extract the non-grouping properties from the object for item handlers
         const nonGroupingProps: ImmutableProps = {};
-        Object.keys(immutableProps).forEach(prop => {
+        Object.keys(currentImmutableProps).forEach(prop => {
             if (!this.groupingProperties.includes(prop as K)) {
-                nonGroupingProps[prop] = immutableProps[prop];
+                nonGroupingProps[prop] = currentImmutableProps[prop];
             }
         });
         
         // Notify item removed handlers at parent key path + groupKey
         this.itemRemovedHandlers.forEach(handler => handler([...parentKeyPath, groupKey], itemKey, nonGroupingProps));
-        
-        // Remove item key from tracking
-        this.itemKeyToGroupKey.delete(itemKey);
-        this.itemKeyToParentKeyPath.delete(itemKey);
-        this.itemKeyToCompositeKey.delete(itemKey);
-        this.itemKeyToImmutableProps.delete(itemKey);
-        this.itemKeyToGroupingValues.delete(itemKey);
+
+        this.trackedItems.delete(itemKey);
         
         // Remove item key from group's set - use composite key for per-parent tracking
         const itemKeys = this.groupKeyToItemKeys.get(compositeKey);
@@ -471,12 +458,7 @@ export class GroupByStep<
             // Check if group is empty
             if (itemKeys.size === 0) {
                 // Extract the grouping property values from the object for group handlers
-                const groupingValues: ImmutableProps = {};
-                Object.keys(immutableProps).forEach(prop => {
-                    if (this.groupingProperties.includes(prop as K)) {
-                        groupingValues[prop] = immutableProps[prop];
-                    }
-                });
+                const groupingValues = trackedItem.groupingValues;
                 
                 // Notify group removed handlers at parent key path
                 this.groupRemovedHandlers.forEach(handler => handler(parentKeyPath, groupKey, groupingValues));

--- a/src/test/pipeline.commutative-aggregate.test.ts
+++ b/src/test/pipeline.commutative-aggregate.test.ts
@@ -10,6 +10,55 @@ import { createTestPipeline } from './helpers';
 type NumericAddOp = AddOperator<ImmutableProps, number>;
 type NumericSubtractOp = SubtractOperator<ImmutableProps, number>;
 
+class FakeInputStep implements Step {
+    private readonly addedHandlers: Map<string, Array<(keyPath: string[], key: string, immutableProps: ImmutableProps) => void>> = new Map();
+    private readonly removedHandlers: Map<string, Array<(keyPath: string[], key: string, immutableProps: ImmutableProps) => void>> = new Map();
+    private readonly modifiedHandlers: Map<string, Array<(keyPath: string[], key: string, oldValue: unknown, newValue: unknown) => void>> = new Map();
+
+    onAdded(pathSegments: string[], handler: (keyPath: string[], key: string, immutableProps: ImmutableProps) => void): void {
+        const pathKey = JSON.stringify(pathSegments);
+        const handlers = this.addedHandlers.get(pathKey) ?? [];
+        handlers.push(handler);
+        this.addedHandlers.set(pathKey, handlers);
+    }
+
+    onRemoved(pathSegments: string[], handler: (keyPath: string[], key: string, immutableProps: ImmutableProps) => void): void {
+        const pathKey = JSON.stringify(pathSegments);
+        const handlers = this.removedHandlers.get(pathKey) ?? [];
+        handlers.push(handler);
+        this.removedHandlers.set(pathKey, handlers);
+    }
+
+    onModified(pathSegments: string[], propertyName: string, handler: (keyPath: string[], key: string, oldValue: unknown, newValue: unknown) => void): void {
+        const registrationKey = `${JSON.stringify(pathSegments)}::${propertyName}`;
+        const handlers = this.modifiedHandlers.get(registrationKey) ?? [];
+        handlers.push(handler);
+        this.modifiedHandlers.set(registrationKey, handlers);
+    }
+
+    emitAdded(pathSegments: string[], keyPath: string[], key: string, immutableProps: ImmutableProps): void {
+        const pathKey = JSON.stringify(pathSegments);
+        (this.addedHandlers.get(pathKey) ?? []).forEach(handler => handler(keyPath, key, immutableProps));
+    }
+
+    emitRemoved(pathSegments: string[], keyPath: string[], key: string, immutableProps: ImmutableProps): void {
+        const pathKey = JSON.stringify(pathSegments);
+        (this.removedHandlers.get(pathKey) ?? []).forEach(handler => handler(keyPath, key, immutableProps));
+    }
+
+    emitModified(
+        pathSegments: string[],
+        propertyName: string,
+        keyPath: string[],
+        key: string,
+        oldValue: unknown,
+        newValue: unknown
+    ): void {
+        const registrationKey = `${JSON.stringify(pathSegments)}::${propertyName}`;
+        (this.modifiedHandlers.get(registrationKey) ?? []).forEach(handler => handler(keyPath, key, oldValue, newValue));
+    }
+}
+
 function graphFromPipelineBuilder(builder: PipelineBuilder) {
     return buildStepGraph((builder as { lastBuilder: StepBuilder }).lastBuilder);
 }
@@ -1238,6 +1287,47 @@ describe('CommutativeAggregateStep', () => {
                 group = output.find(g => g.category === 'A');
                 expect(group?.count).toBe(2);
             });
+        });
+    });
+
+    describe('mutable property item snapshots', () => {
+        it('should pass the full tracked item to operators during mutable updates', () => {
+            const fakeInput = new FakeInputStep();
+            type WeightedItem = { quantity: number; unitPrice: number };
+            const aggregateStep = new CommutativeAggregateStep<WeightedItem, ['items'], 'weightedTotal', number>(
+                fakeInput,
+                ['items'],
+                'weightedTotal',
+                {
+                    add: (acc, item) => (acc ?? 0) + item.quantity * item.unitPrice,
+                    subtract: (acc, item) => acc - item.quantity * item.unitPrice
+                },
+                'quantity',
+                {
+                    rootCollectionName: 'items',
+                    arrays: [],
+                    collectionKey: [],
+                    scalars: [
+                        { name: 'quantity', type: 'number' },
+                        { name: 'unitPrice', type: 'number' }
+                    ],
+                    objects: [],
+                    mutableProperties: ['quantity']
+                }
+            );
+
+            const modifiedEvents: Array<{ oldValue: number | undefined; newValue: number }> = [];
+            aggregateStep.onModified([], 'weightedTotal', (_path, _key, oldValue, newValue) => {
+                modifiedEvents.push({ oldValue: oldValue as number | undefined, newValue: newValue as number });
+            });
+
+            fakeInput.emitAdded(['items'], [], 'row-1', { quantity: 2, unitPrice: 5 });
+            fakeInput.emitModified(['items'], 'quantity', [], 'row-1', 2, 3);
+
+            expect(modifiedEvents).toEqual([
+                { oldValue: undefined, newValue: 10 },
+                { oldValue: 10, newValue: 15 }
+            ]);
         });
     });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove unsafe pipeline source binding and builder type-bypass patterns
- preserve aggregate item typing across commutative aggregate boundaries
- collapse redundant per-item and average caches in step state
- track full aggregate item snapshots so mutable updates honor the operator item contract

## Testing
- npm run typecheck
- npx jest src/test/pipeline.aggregate-functions.test.ts src/test/pipeline.commutative-aggregate.test.ts src/test/pipeline.group-by.test.ts src/test/pipeline.auto-detect-mutable.test.ts src/test/pipeline.enrich.mutable-primary-key.test.ts src/test/pipeline.enrich.test.ts src/test/pipeline.mutable-properties.test.ts --runInBand
- npm run build && npm run test:types
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d36d2f6-3ea7-4b07-ab7c-7573639aa6fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d36d2f6-3ea7-4b07-ab7c-7573639aa6fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

